### PR TITLE
[Docs] Changed 'Preferences' to the correct name of 'Settings'

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -1,8 +1,8 @@
 = Installation
 
-. Select menu:Preferences[Plugins > ⚙ > Manage Plugin Repositories].
+. Select menu:Settings[Plugins > ⚙ > Manage Plugin Repositories].
 . Add https://github.com/apple/pkl-intellij/releases/latest/download/updatePlugins.xml to the list of custom plugin repositories.
-. Select menu:Preferences[Plugins > Marketplace].
+. Select menu:Settings[Plugins > Marketplace].
 . Search for and install the _pkl_ plugin.
 
 You will be notified when a new plugin version is available.


### PR DESCRIPTION
In Current vesions of Jetbrains Ides there is no tab called 'Preferences' insted its called 'Settings'.

![image](https://github.com/apple/pkl-intellij/assets/68086870/ce901d6c-04f9-4b0f-a344-b1b9f8ca92ab)
