### PR TITLE
Improve semver handling in package uris

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/annotator/PklModuleUriAndVersionAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklModuleUriAndVersionAnnotator.kt
@@ -22,7 +22,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import com.intellij.util.text.SemVer
 import java.net.URI
 import java.net.URISyntaxException
 import org.pkl.intellij.PklVersion
@@ -31,6 +30,7 @@ import org.pkl.intellij.intention.PklPrefixDependencyNotationQuickFix
 import org.pkl.intellij.packages.PackageDependency
 import org.pkl.intellij.packages.dto.Checksums
 import org.pkl.intellij.packages.dto.PackageUri
+import org.pkl.intellij.packages.dto.Version
 import org.pkl.intellij.packages.pklPackageService
 import org.pkl.intellij.psi.*
 import org.pkl.intellij.util.currentProject
@@ -170,7 +170,7 @@ class PklModuleUriAndVersionAnnotator : PklAnnotator() {
       return true
     }
     val versionAndChecksumParts = versionAndChecksumPart.split("::")
-    val version = SemVer.parseFromText(versionAndChecksumParts.first())
+    val version = Version.parseOrNull(versionAndChecksumParts.first())
     if (version == null) {
       val offset = element.text.lastIndexOf('@') + 1
       createAnnotation(

--- a/src/main/kotlin/org/pkl/intellij/packages/dto/PackageUri.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/dto/PackageUri.kt
@@ -15,7 +15,6 @@
  */
 package org.pkl.intellij.packages.dto
 
-import com.intellij.util.text.SemVer
 import java.net.URI
 import java.net.URISyntaxException
 import java.util.*
@@ -33,7 +32,7 @@ import org.pkl.intellij.packages.PackageDependency
 data class PackageUri(
   val authority: String,
   val path: String,
-  val version: SemVer,
+  val version: Version,
   val checksums: Checksums?
 ) {
   private val basePath = path.substringBeforeLast('@')
@@ -45,7 +44,7 @@ data class PackageUri(
 
       override fun deserialize(decoder: Decoder): PackageUri {
         val str = decoder.decodeString()
-        return create(str)!!
+        return create(str) ?: throw IllegalArgumentException("Invalid package uri: $str")
       }
 
       override fun serialize(encoder: Encoder, value: PackageUri) {
@@ -68,7 +67,7 @@ data class PackageUri(
           Checksums(value)
         } else null
       val versionStr = versionAndChecksumPart.substringBeforeLast("::")
-      val version = SemVer.parseFromText(versionStr) ?: return null
+      val version = Version.parseOrNull(versionStr) ?: return null
       return PackageUri(authority, path, version, checksums)
     }
 

--- a/src/main/kotlin/org/pkl/intellij/packages/dto/Version.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/dto/Version.kt
@@ -20,9 +20,7 @@ import kotlin.math.min
 
 /** Adapted from `org.pkl.core.Version` */
 data class Version(
-  /** Returns the major version. */
   val major: Int,
-  /** Returns the minor version. */
   var minor: Int,
   val patch: Int,
   val preRelease: String?,

--- a/src/main/kotlin/org/pkl/intellij/packages/dto/Version.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/dto/Version.kt
@@ -1,0 +1,130 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.packages.dto
+
+import java.util.regex.Pattern
+import kotlin.math.min
+
+/** Adapted from `org.pkl.core.Version` */
+data class Version(
+  /** Returns the major version. */
+  val major: Int,
+  /** Returns the minor version. */
+  var minor: Int,
+  val patch: Int,
+  val preRelease: String?,
+  val build: String?
+) : Comparable<Version> {
+
+  /** Compares this version to the given version according to semantic versioning rules. */
+  override operator fun compareTo(other: Version): Int {
+    return COMPARATOR.compare(this, other)
+  }
+
+  override fun toString(): String {
+    return buildString {
+      append(major)
+      append(".")
+      append(minor)
+      append(".")
+      append(patch)
+      if (preRelease != null) append("-").append(preRelease)
+      if (build != null) append("+").append(build)
+    }
+  }
+
+  private val preReleaseIdentifiers: List<Identifier> by lazy {
+    preRelease
+      ?.split(".")
+      ?.dropLastWhile { it.isEmpty() }
+      ?.map { str ->
+        if (NUMERIC_IDENTIFIER.matcher(str).matches()) Identifier(str.toLong(), null)
+        else Identifier(-1, str)
+      }
+      ?: emptyList()
+  }
+
+  private class Identifier(private val numericId: Long, private val alphanumericId: String?) :
+    Comparable<Identifier> {
+    override operator fun compareTo(other: Identifier): Int {
+      return if (alphanumericId != null)
+        if (other.alphanumericId != null) alphanumericId.compareTo(other.alphanumericId) else 1
+      else if (other.alphanumericId != null) -1 else numericId.compareTo(other.numericId)
+    }
+  }
+
+  companion object {
+    // https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
+    private val VERSION = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-([^+]+))?(?:\\+(.+))?")
+    private val NUMERIC_IDENTIFIER = Pattern.compile("(0|[1-9]\\d*)")
+    private val COMPARATOR =
+      Comparator.comparingInt { obj: Version -> obj.major }
+        .thenComparingInt { obj: Version -> obj.minor }
+        .thenComparingInt { obj: Version -> obj.patch }
+        .thenComparing { v1: Version, v2: Version ->
+          if (v1.preRelease == null) return@thenComparing if (v2.preRelease == null) 0 else 1
+          if (v2.preRelease == null) return@thenComparing -1
+          val ids1 = v1.preReleaseIdentifiers
+          val ids2 = v2.preReleaseIdentifiers
+          val minSize = min(ids1.size.toDouble(), ids2.size.toDouble()).toInt()
+          for (i in 0 until minSize) {
+            val result = ids1[i].compareTo(ids2[i])
+            if (result != 0) return@thenComparing result
+          }
+          ids1.size.compareTo(ids2.size)
+        }
+
+    /**
+     * Parses the given string as a semantic version number.
+     *
+     * Throws [IllegalArgumentException] if the given string could not be parsed as a semantic
+     * version number or is too large to fit into a [Version].
+     */
+    fun parse(version: String): Version {
+      val result = parseOrNull(version)
+      if (result != null) return result
+      require(!VERSION.matcher(version).matches()) {
+        String.format("`%s` is too large to fit into a Version.", version)
+      }
+      throw IllegalArgumentException(
+        String.format("`%s` could not be parsed as a semantic version number.", version)
+      )
+    }
+
+    /**
+     * Parses the given string as a semantic version number.
+     *
+     * Returns `null` if the given string could not be parsed as a semantic version number or is too
+     * large to fit into a [Version].
+     */
+    fun parseOrNull(version: String): Version? {
+      val matcher = VERSION.matcher(version)
+      return if (!matcher.matches()) null
+      else
+        try {
+          Version(
+            matcher.group(1).toInt(),
+            matcher.group(2).toInt(),
+            matcher.group(3).toInt(),
+            matcher.group(4),
+            matcher.group(5)
+          )
+        } catch (e: NumberFormatException) {
+          null
+        }
+    }
+  }
+}


### PR DESCRIPTION
Previously, we were using the com.intellij.util.text.SemVer library, but it cannot handle some build tags (e.g. `0.1.0+0.1.0`).