### PR TITLE
Fix runtime crash from `PklCreateProjectAction` in 2024.1+

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/action/PklCreateProjectAction.kt
+++ b/src/main/kotlin/org/pkl/intellij/action/PklCreateProjectAction.kt
@@ -17,6 +17,7 @@ package org.pkl.intellij.action
 
 import com.intellij.ide.IdeBundle
 import com.intellij.ide.IdeView
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.LangDataKeys.IDE_VIEW
@@ -43,6 +44,10 @@ class PklCreateProjectAction :
     val view = IDE_VIEW.getData(e.dataContext) ?: return
     val isAvailable = !hasPklProject(view)
     e.presentation.isEnabledAndVisible = isAvailable
+  }
+
+  override fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.BGT
   }
 
   override fun actionPerformed(e: AnActionEvent) {


### PR DESCRIPTION
Fix a runtime crash happening in IDEA 2024.1+:
```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'org.pkl.intellij.action.PklCreateProjectAction' must override `getActionUpdateThread` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: org.pkl]
```

As its `update` function doesn't perform any EDT-specific action, BGT works fine for this case.