### PR TITLE
Fix triple-dot uri resolution

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -439,7 +439,7 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       var currentDir = sourceFile.parent?.parent
       while (currentDir != null) {
         val result = currentDir.findFileByRelativePath(targetPathAfterTripleDot)
-        if (result != null) return result
+        if (result != null && result.path != sourceFile.path) return result
         currentDir = currentDir.parent
       }
 


### PR DESCRIPTION
This fixes an issue where the plugin might resolve a triple-dot import to the same file, which can never happen in practice.