### PR TITLE
Add support for inferring types of const/fixed members

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
@@ -47,13 +47,16 @@ interface PklModifierListOwner : PklElement {
   val isAbstractOrOpen: Boolean
     get() = hasEitherModifier(PklElementTypes.ABSTRACT, PklElementTypes.OPEN)
 
+  val isLocalOrConstOrFixed: Boolean
+    get() = hasEitherModifier(PklElementTypes.LOCAL, PklElementTypes.CONST, PklElementTypes.FIXED)
+
   private fun hasModifier(modifier: IElementType): Boolean {
     val modifiers = modifierList?.elements ?: return false
     return modifiers.any { it.elementType == modifier }
   }
 
-  private fun hasEitherModifier(modifier1: IElementType, modifier2: IElementType): Boolean {
-    val modifiers = modifierList?.elements ?: return false
-    return modifiers.any { it.elementType == modifier1 || it.elementType == modifier2 }
+  private fun hasEitherModifier(vararg modifiers: IElementType): Boolean {
+    val myModifiers = modifierList?.elements ?: return false
+    return myModifiers.any { modifiers.contains(it.elementType) }
   }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
@@ -16,8 +16,18 @@
 package org.pkl.intellij.psi
 
 import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
 
 interface PklModifierListOwner : PklElement {
+  companion object {
+    private val constOrFixed = TokenSet.create(PklElementTypes.CONST, PklElementTypes.FIXED)
+
+    private val localOrConstOrFixed =
+      TokenSet.create(PklElementTypes.LOCAL, PklElementTypes.CONST, PklElementTypes.FIXED)
+
+    private val abstractOrOpen = TokenSet.create(PklElementTypes.ABSTRACT, PklElementTypes.OPEN)
+  }
+
   val modifierList: PklModifierList?
 
   val isAbstract: Boolean
@@ -42,21 +52,21 @@ interface PklModifierListOwner : PklElement {
     get() = hasModifier(PklElementTypes.CONST)
 
   val isFixedOrConst: Boolean
-    get() = hasEitherModifier(PklElementTypes.CONST, PklElementTypes.FIXED)
+    get() = hasEitherModifier(constOrFixed)
 
   val isAbstractOrOpen: Boolean
-    get() = hasEitherModifier(PklElementTypes.ABSTRACT, PklElementTypes.OPEN)
+    get() = hasEitherModifier(abstractOrOpen)
 
   val isLocalOrConstOrFixed: Boolean
-    get() = hasEitherModifier(PklElementTypes.LOCAL, PklElementTypes.CONST, PklElementTypes.FIXED)
+    get() = hasEitherModifier(localOrConstOrFixed)
 
   private fun hasModifier(modifier: IElementType): Boolean {
     val modifiers = modifierList?.elements ?: return false
     return modifiers.any { it.elementType == modifier }
   }
 
-  private fun hasEitherModifier(vararg modifiers: IElementType): Boolean {
-    val myModifiers = modifierList?.elements ?: return false
-    return myModifiers.any { modifiers.contains(it.elementType) }
+  private fun hasEitherModifier(tokenSet: TokenSet): Boolean {
+    val modifiers = modifierList?.elements ?: return false
+    return modifiers.any { tokenSet.contains(it.elementType) }
   }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
@@ -52,20 +52,20 @@ interface PklModifierListOwner : PklElement {
     get() = hasModifier(PklElementTypes.CONST)
 
   val isFixedOrConst: Boolean
-    get() = hasEitherModifier(constOrFixed)
+    get() = hasAnyModifier(constOrFixed)
 
   val isAbstractOrOpen: Boolean
-    get() = hasEitherModifier(abstractOrOpen)
+    get() = hasAnyModifier(abstractOrOpen)
 
   val isLocalOrConstOrFixed: Boolean
-    get() = hasEitherModifier(localOrConstOrFixed)
+    get() = hasAnyModifier(localOrConstOrFixed)
 
   private fun hasModifier(modifier: IElementType): Boolean {
     val modifiers = modifierList?.elements ?: return false
     return modifiers.any { it.elementType == modifier }
   }
 
-  private fun hasEitherModifier(tokenSet: TokenSet): Boolean {
+  private fun hasAnyModifier(tokenSet: TokenSet): Boolean {
     val modifiers = modifierList?.elements ?: return false
     return modifiers.any { tokenSet.contains(it.elementType) }
   }

--- a/src/main/kotlin/org/pkl/intellij/type/ComputeDefinitionType.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/ComputeDefinitionType.kt
@@ -48,7 +48,7 @@ fun PsiElement?.computeResolvedImportType(
           type != null -> type.toType(base, bindings, preserveUnboundTypeVars)
           else ->
             when {
-              canInferExprBody && isLocal -> expr.computeExprType(base, bindings)
+              canInferExprBody && isLocalOrConstOrFixed -> expr.computeExprType(base, bindings)
               isDefinition -> Type.Unknown
               else -> {
                 val receiverType = computeThisType(base, bindings)


### PR DESCRIPTION
These are values where the type cannot by changed by amending, so it makes sense to provide inference support for them.

Also: minor refactor to use TokenSet.