### PR TITLE
Fix rendering of type names in documentation

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/documentation/PklDocumentationProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/documentation/PklDocumentationProvider.kt
@@ -290,7 +290,7 @@ class PklDocumentationProvider : AbstractDocumentationProvider() {
           val computedType =
             Resolvers.resolveUnqualifiedAccess(
               originalElement,
-              null,
+              element.computeThisType(base, mapOf()),
               true,
               element.project.pklBaseModule,
               mapOf(),


### PR DESCRIPTION
This fixes an issue where the type of a parameter might be shown incorrectly as "unknown" in documentation (e.g. on hover).