### PR TITLE
Project sync fixes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ intellij = "2023.1.5"
 # IntelliJ version to run against (`runIde` task). Use latest version.
 # https://www.jetbrains.com/idea/download/#section=mac
 intellijRunIde = "2023.2"
-intellijPlugin = "1.15.0"
+intellijPlugin = "1.17.4"
 intellijSinceBuild = "231"
 # set to "999.*" to disable upper bound
 intellijUntilBuild = "241.*"

--- a/src/main/kotlin/org/pkl/intellij/packages/PklProjectFileModificationTracker.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/PklProjectFileModificationTracker.kt
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.packages
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import java.util.concurrent.atomic.AtomicLong
+import org.pkl.intellij.PklFileType
+import org.pkl.intellij.packages.PklProjectService.Companion.PKL_PROJECT_FILENAME
+
+fun Project.pklProjectModificationTracker(): PklProjectFileModificationTracker = service()
+
+/**
+ * Keeps track of add/delete/move/property change events for PklProject files within the project.
+ */
+@Service(Service.Level.PROJECT)
+class PklProjectFileModificationTracker(project: Project) : ModificationTracker {
+  init {
+    project.messageBus
+      .connect()
+      .subscribe(
+        VirtualFileManager.VFS_CHANGES,
+        object : BulkFileListener {
+          override fun after(events: List<VFileEvent>) {
+            for (event in events) {
+              if (event is VFileContentChangeEvent) continue
+              if (event.file?.fileType == PklFileType && event.file?.name == PKL_PROJECT_FILENAME) {
+                modificationCount.getAndIncrement()
+              }
+            }
+          }
+        }
+      )
+  }
+
+  private val modificationCount: AtomicLong = AtomicLong(0)
+
+  override fun getModificationCount(): Long = modificationCount.get()
+}

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModule.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModule.kt
@@ -90,6 +90,15 @@ interface PklModule : PsiFile, PklTypeDefOrModule {
 
   val `package`: PackageDependency?
 
+  /** Tells if this module is an ancestor of a directory that contains a PklProject file. */
+  val isInPklProject: Boolean
+
+  /**
+   * The closest synced PklProject for this module.
+   *
+   * Value is `null` if the module is either not inside a Pkl project, or if the project has not
+   * been synced.
+   */
   val pklProject: PklProject?
 
   /**

--- a/src/main/kotlin/org/pkl/intellij/util/Util.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/Util.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderEnumerator
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -362,7 +363,7 @@ fun <T> PklElement.getContextualCachedValue(
       this,
       Key.create("${context.projectFile}-cache"),
       {
-        val result = provider.compute() ?: return@getCachedValue null
+        val result = provider.compute() ?: return@getCachedValue noCacheResult()
         CachedValueProvider.Result.create(
           result.value,
           project.pklProjectService,
@@ -372,3 +373,6 @@ fun <T> PklElement.getContextualCachedValue(
       false
     )
 }
+
+fun <T> noCacheResult(): CachedValueProvider.Result<T> =
+  CachedValueProvider.Result.create(null, ModificationTracker.EVER_CHANGED)

--- a/src/test/kotlin/org/pkl/intellij/completion/CompletionTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/completion/CompletionTest.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.completion
 
+import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.pkl.intellij.PklFileType
 import org.pkl.intellij.PklTestCase
@@ -99,7 +100,6 @@ class CompletionTest : PklTestCase() {
     assertThat(lookupStrings).contains("configMaps = ")
   }
 
-  override fun getTestDataPath(): String {
-    return "src/test/resources/completion"
-  }
+  override val fixtureDir: Path?
+    get() = Path.of("src/test/resources/completion")
 }

--- a/src/test/kotlin/org/pkl/intellij/resolve/LocalProjectResolveTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/resolve/LocalProjectResolveTest.kt
@@ -15,8 +15,7 @@
  */
 package org.pkl.intellij.resolve
 
-import com.intellij.testFramework.fixtures.*
-import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
+import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.pkl.intellij.PklTestCase
 import org.pkl.intellij.psi.PklClassProperty
@@ -30,11 +29,7 @@ class LocalProjectResolveTest : PklTestCase() {
     syncProjects()
   }
 
-  override fun getTestDataPath(): String = "src/test/resources/resolve/projects"
-
-  // force use of real temp dirs instead of in-memory virtual files because we need to resolve them
-  // using the pkl CLI.
-  override fun createTempDirTestFixture(): TempDirTestFixture = TempDirTestFixtureImpl()
+  override val fixtureDir: Path = Path.of("src/test/resources/resolve/projects")
 
   fun `test that imports resolve to package dependencies`() {
     myFixture.configureByFile("project1/moduleCompletion1.pkl")


### PR DESCRIPTION
* Fix an issue where running the "Sync Projects" action does not clear "unresolved import" diagnostics
* Show the "Sync Projects" banner on any Pkl module that is within a PklProject root if the project is not synced
* Skip ignored files (e.g. `gitignore`) when discovering PklProject files
* Fix issue where cached values do not get invalidated correctly