### PR TITLE
Infer interpolated string literal types

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/type/Types.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/Types.kt
@@ -1104,6 +1104,10 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       if (rightType is Union) rightType.eachElementType(processor) else processor(rightType)
     }
 
+    fun <T> map(f: (Type) -> T): List<T> {
+      return buildList { eachElementType { add(f(it)) } }
+    }
+
     override fun equals(other: Any?): Boolean =
       when {
         this === other -> true
@@ -1124,6 +1128,12 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
     val isUnionOfStringLiterals: Boolean by lazy {
       (leftType is StringLiteral || leftType is Union && leftType.isUnionOfStringLiterals) &&
         (rightType is StringLiteral || rightType is Union && rightType.isUnionOfStringLiterals)
+    }
+
+    val cardinality: Int by lazy {
+      val left = if (leftType is Union) leftType.cardinality else 1
+      val right = if (rightType is Union) rightType.cardinality else 1
+      left + right
     }
   }
 }


### PR DESCRIPTION
This adds type inference for string literals that are interpolated, where the interpolated expressions themselves compute to string literal types.

Screenshots:

<img width="413" alt="Screenshot 2024-09-10 at 2 06 12 PM" src="https://github.com/user-attachments/assets/32985071-71b1-4563-91e7-5528d3194a87">

<img width="401" alt="Screenshot 2024-09-10 at 2 06 51 PM" src="https://github.com/user-attachments/assets/6d68e31d-840a-4081-b107-ebaff28e1016">

<img width="467" alt="Screenshot 2024-09-10 at 2 07 44 PM" src="https://github.com/user-attachments/assets/61a3af89-2c4e-46ae-b3bb-4e36e472086b">