### PR TITLE
Add support for const object members

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/PklVersion.kt
+++ b/src/main/kotlin/org/pkl/intellij/PklVersion.kt
@@ -58,6 +58,7 @@ class PklVersion(
 
     @Suppress("unused") val VERSION_0_25: PklVersion = PklVersion(0, 25, 0, null, null)
     val VERSION_0_26: PklVersion = PklVersion(0, 26, 0, null, null)
+    val VERSION_0_27: PklVersion = PklVersion(0, 27, 0, null, null)
 
     fun parse(versionString: String): PklVersion? {
       val result = REGEX.matchEntire(versionString) ?: return null

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklMemberAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklMemberAnnotator.kt
@@ -419,14 +419,16 @@ class PklMemberAnnotator : PklAnnotator() {
     if (module.effectivePklVersion >= PklVersion.VERSION_0_27) {
       if (constModifier != null && owner is PklObjectMember) {
         if (localModifier == null) {
-          val annotation = holder
-            .newAnnotation(HighlightSeverity.ERROR, "Modifier 'const' can only be applied to object members who are also 'local'")
-            .range(constModifier)
+          val annotation =
+            holder
+              .newAnnotation(
+                HighlightSeverity.ERROR,
+                "Modifier 'const' can only be applied to object members who are also 'local'"
+              )
+              .range(constModifier)
           if (holder.currentFile.canModify()) {
             val modifierList = owner.modifierList!!
-            annotation.withFix(
-              PklAddModifierQuickFix("Add modifier 'local'", modifierList, LOCAL)
-            )
+            annotation.withFix(PklAddModifierQuickFix("Add modifier 'local'", modifierList, LOCAL))
           }
           annotation.create()
         }

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklUnsupportedFeatureAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklUnsupportedFeatureAnnotator.kt
@@ -26,9 +26,10 @@ import org.pkl.intellij.util.escapeXml
 class PklUnsupportedFeatureAnnotator : PklAnnotator() {
 
   private fun getToolTip(feature: Feature, detectedVersion: PklVersion): String {
+    val message = feature.message ?: "Unsupported feature: ${feature.featureName}."
     // language=html
     return """
-      Unsupported feature: ${feature.featureName}.
+      $message
       <table>
         <tr><td style="text-align: right">Required Pkl version:</td><td><code>${feature.requiredVersion.toString().escapeXml()}</code></td></tr>
         <tr><td style="text-align: right">Detected Pkl version:</td><td><code>${detectedVersion.toString().escapeXml()}</code></td></tr>
@@ -42,10 +43,11 @@ class PklUnsupportedFeatureAnnotator : PklAnnotator() {
     val feature: Feature = Feature.features.find { it.predicate(element) } ?: return
     if (feature.isSupported(containingModule)) return
     val tooltip = getToolTip(feature, containingModule.effectivePklVersion)
+    val message = feature.message ?: "Unsupported feature: ${feature.featureName}"
     createAnnotation(
       HighlightSeverity.WARNING,
       element.textRange,
-      "Unsupported feature: ${feature.featureName}." +
+      message +
         " Required Pkl version: ${feature.requiredVersion}. Detected Pkl version: ${containingModule.effectivePklVersion}.",
       tooltip,
       holder,

--- a/src/main/kotlin/org/pkl/intellij/util/Feature.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/Feature.kt
@@ -17,17 +17,26 @@ package org.pkl.intellij.util
 
 import com.intellij.psi.PsiElement
 import org.pkl.intellij.PklVersion
-import org.pkl.intellij.psi.PklModule
+import org.pkl.intellij.psi.*
 
-sealed class Feature(
-  val featureName: String,
-  val requiredVersion: PklVersion,
+sealed interface Feature {
+  val featureName: String
+  val requiredVersion: PklVersion
   val predicate: (PsiElement) -> Boolean
-) {
+  val message: String? get() = null
 
   fun isSupported(module: PklModule): Boolean = module.effectivePklVersion >= requiredVersion
 
   companion object {
-    val features = listOf<Feature>()
+    val features = listOf<Feature>(ConstObjectMember)
+
+    object ConstObjectMember : Feature {
+      override val featureName: String = "const object member"
+      override val requiredVersion: PklVersion = PklVersion.VERSION_0_27
+      override val predicate: (PsiElement) -> Boolean = { elem ->
+        elem.elementType == PklElementTypes.CONST && elem.parent.parent is PklObjectMember
+      }
+      override val message: String = "Modifier 'const' cannot be applied to object members in this Pkl version."
+    }
   }
 }

--- a/src/main/kotlin/org/pkl/intellij/util/Feature.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/Feature.kt
@@ -23,7 +23,8 @@ sealed interface Feature {
   val featureName: String
   val requiredVersion: PklVersion
   val predicate: (PsiElement) -> Boolean
-  val message: String? get() = null
+  val message: String?
+    get() = null
 
   fun isSupported(module: PklModule): Boolean = module.effectivePklVersion >= requiredVersion
 
@@ -36,7 +37,8 @@ sealed interface Feature {
       override val predicate: (PsiElement) -> Boolean = { elem ->
         elem.elementType == PklElementTypes.CONST && elem.parent.parent is PklObjectMember
       }
-      override val message: String = "Modifier 'const' cannot be applied to object members in this Pkl version."
+      override val message: String =
+        "Modifier 'const' cannot be applied to object members in this Pkl version."
     }
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -115,8 +115,7 @@
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklExtendsClauseAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklTypeNameAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklHighlightingAnnotator"/>
-    <!-- Not used for now because all Pkl features are supported in all versions -->
-    <!-- <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklUnsupportedFeatureAnnotator"/> -->
+    <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklUnsupportedFeatureAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklReservedKeywordAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklIgnoreAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklTypeAnnotator"/>


### PR DESCRIPTION
If `local` is missing:

<img width="568" alt="Screenshot 2024-11-05 at 1 36 25 PM" src="https://github.com/user-attachments/assets/95fba694-0235-422b-a976-2612ebd618a4">

If used in 0.26 and earlier:

<img width="563" alt="Screenshot 2024-11-05 at 1 35 09 PM" src="https://github.com/user-attachments/assets/e22e934e-2809-4541-9eee-42c43c7fe38d">
