### PR TITLE
Bugfix/Formatter: properly space object and class properties

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/formatter/PklFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/pkl/intellij/formatter/PklFormattingModelBuilder.kt
@@ -50,6 +50,13 @@ class PklFormattingModelBuilder : FormattingModelBuilder {
         POW
       )
 
+    val PROPERTY =
+      TokenSet.create(
+        MODULE_MEMBER,
+        CLASS_PROPERTY,
+        OBJECT_PROPERTY,
+      )
+
     val TIGHT_OPERATORS = TokenSet.create(DOT, QDOT, UNION)
 
     val METHOD_STYLE_KEYWORDS = TokenSet.create(IMPORT_KEYWORD, READ, READ_OR_NULL, THROW, TRACE)
@@ -103,6 +110,8 @@ class PklFormattingModelBuilder : FormattingModelBuilder {
         .spacing(1, 1, 0, false, 0) // class Foo {
         .before(OBJECT_BODY)
         .spacing(1, 1, 0, false, 0) // foo {
+        .before(PROPERTY)
+        .spacing(1, 1, 0, true, 1) // foo =
 
     return FormattingModelProvider.createFormattingModelForPsiFile(
       context.psiElement.containingFile,

--- a/src/test/kotlin/org/pkl/intellij/formatter/PklFormatterTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/formatter/PklFormatterTest.kt
@@ -23,11 +23,41 @@ class PklFormatterTest : FormatterTestCase() {
       """
       foo = (x) -> x {
         }
+      bar {
+      asdf = "hey"whoa="no"
+       cccc = "lol" 
+         aaaa ="cool" 
+         bbb =   "neato"    ddd = "burrito"
+      } class Hey {
+      asdf = "hey"whoa="no"
+       cccc = "lol" 
+         aaaa ="cool" 
+         bbb =   "neato"    ddd = "burrito"
+      }
+      masdf = "hey"mwhoa="no"
+       mcccc = "lol" 
+         maaaa ="cool" 
+         mbbb =   "neato"    mddd = "burrito"
       """
         .trimIndent(),
       """
       foo = (x) -> x {
       }
+      bar {
+        asdf = "hey" whoa = "no"
+        cccc = "lol"
+        aaaa = "cool"
+        bbb = "neato" ddd = "burrito"
+      } class Hey {
+        asdf = "hey" whoa = "no"
+        cccc = "lol"
+        aaaa = "cool"
+        bbb = "neato" ddd = "burrito"
+      }
+      masdf = "hey" mwhoa = "no"
+      mcccc = "lol"
+      maaaa = "cool"
+      mbbb = "neato" mddd = "burrito"
       """
         .trimIndent()
     )


### PR DESCRIPTION
<img width="436" alt="image" src="https://github.com/user-attachments/assets/a1fafc64-6274-4bd4-a017-417dc7477f19">

Currently, if you hit backspace on an Module/Class/Object property, the formatting rules don't protect the name of the property from being concatenated to the line above.

Here I am adding a rule to ensure a space before the property name when reformatting and backspacing

Possibly fixes: https://github.com/apple/pkl-intellij/issues/26