### PR TITLE
Add annotator for missing but required Class properties

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/annotator/PklMissingPropertiesAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklMissingPropertiesAnnotator.kt
@@ -107,12 +107,12 @@ private fun insertRequiredProperties(
   base: PklBaseModule,
   context: PklProject?
 ) {
-  props.forEach {
-    val propertyType = it.getLookupElementType(base, mapOf(), context)
-    val nullable = propertyType.isNullable(base)
-    val hasDefault = it.expr != null
-    if (!nullable && !hasDefault) {
-      results[it.propertyName.identifier.text] = propertyType.render()
+  props
+    .filter { it.expr == null }
+    .forEach {
+      val propertyType = it.getLookupElementType(base, mapOf(), context)
+      if (!propertyType.isNullable(base)) {
+        results[it.propertyName.identifier.text] = propertyType.render()
+      }
     }
-  }
 }

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklMissingPropertiesAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklMissingPropertiesAnnotator.kt
@@ -1,0 +1,118 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiElement
+import org.pkl.intellij.packages.dto.PklProject
+import org.pkl.intellij.psi.*
+import org.pkl.intellij.type.Type
+import org.pkl.intellij.type.computeThisType
+import org.pkl.intellij.util.currentModule
+
+class PklMissingPropertiesAnnotator : PklAnnotator() {
+
+  override fun doAnnotate(element: PsiElement, holder: AnnotationHolder) {
+    if (element is PklNewExpr) {
+      val base = holder.currentModule?.project?.pklBaseModule ?: return
+      val context = element.enclosingModule?.pklProject
+      val bodyType = element.objectBody?.computeThisType(base, mapOf(), context)
+      val elementTypeName: String
+      val requiredProperties =
+        when (bodyType) {
+          is Type.Class -> {
+            val className = bodyType.psi.name ?: "<class>"
+            elementTypeName =
+              bodyType.psi.enclosingModule?.displayName?.let { "${it}.$className" } ?: className
+            getAllRequiredProperties(bodyType.psi, base, context)
+          }
+          is Type.Module -> {
+            elementTypeName = bodyType.psi.displayName
+            getAllRequiredProperties(bodyType.psi, base, context)
+          }
+          else -> return
+        }
+      val definedPropertyKeys =
+        element.objectBody?.properties?.map { it.propertyName.identifier.text }?.toSet()
+          ?: emptySet()
+      val missingProperties = requiredProperties.minus(definedPropertyKeys)
+      if (missingProperties.isEmpty()) return
+      val missingListMessage = missingProperties.keys.joinToString(", ")
+      val missingListTooltip =
+        missingProperties
+          .map { (k, v) ->
+            "<tr><td><strong><code>$k</code></strong></td><td><code>$v</code></td></tr>"
+          }
+          .joinToString("")
+      createAnnotation(
+        HighlightSeverity.ERROR,
+        element.node.firstChildNode.textRange,
+        "Missing required properties for ${elementTypeName}: $missingListMessage",
+        "Missing required properties for <strong><code>${elementTypeName}</code></strong><table>$missingListTooltip</table>",
+        holder,
+        PklProblemGroups.missingRequiredValues,
+        element,
+      )
+    }
+  }
+}
+
+private fun getAllRequiredProperties(
+  pklClass: PklClass,
+  base: PklBaseModule,
+  context: PklProject?
+): Map<String, String> {
+  val results = mutableMapOf<String, String>()
+  insertRequiredProperties(pklClass.properties, results, base, context)
+  var parent = pklClass.superclass(context)
+  while (parent != null) {
+    insertRequiredProperties(parent.properties, results, base, context)
+    parent = parent.superclass(context)
+  }
+  return results
+}
+
+private fun getAllRequiredProperties(
+  pklModule: PklModule,
+  base: PklBaseModule,
+  context: PklProject?
+): Map<String, String> {
+  val results = mutableMapOf<String, String>()
+  insertRequiredProperties(pklModule.properties, results, base, context)
+  var parent = pklModule.supermodule(context)
+  while (parent != null) {
+    insertRequiredProperties(parent.properties, results, base, context)
+    parent = parent.supermodule(context)
+  }
+  return results
+}
+
+private fun insertRequiredProperties(
+  props: Sequence<PklClassProperty>,
+  results: MutableMap<String, String>,
+  base: PklBaseModule,
+  context: PklProject?
+) {
+  props.forEach {
+    val propertyType = it.getLookupElementType(base, mapOf(), context)
+    val nullable = propertyType.isNullable(base)
+    val hasDefault = it.expr != null
+    if (!nullable && !hasDefault) {
+      results[it.propertyName.identifier.text] = propertyType.render()
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklProblemGroups.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklProblemGroups.kt
@@ -40,6 +40,8 @@ object PklProblemGroups {
   val unsupportedFeature: PklProblemGroup = PklProblemGroup("UnsupportedFeature")
 
   val missingDefaultValue: PklProblemGroup = PklProblemGroup("MissingDefaultValue")
+
+  val missingRequiredValues: PklProblemGroup = PklProblemGroup("MissingRequiredValues")
 }
 
 // implementing `SuppressableProblemGroup` doesn't seem to do anything

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -137,6 +137,7 @@
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklIgnoreAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklTypeAnnotator"/>
     <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklProjectAnnotator"/>
+    <annotator language="Pkl" implementationClass="org.pkl.intellij.annotator.PklMissingPropertiesAnnotator"/>
     <completion.contributor language="Pkl"
                             implementationClass="org.pkl.intellij.completion.PklCompletionContributor"/>
     <completion.confidence language="Pkl"


### PR DESCRIPTION
When refactoring Pkl schemas and classes I find myself losing a lot of time forgetting to fill in "required" (not optional and not defaulted) properties for often very long, flat objects.

I've created an annotator that marks all instances of `new Typed {` that miss any "required" class properties (direct or inherited)

<img width="468" alt="image" src="https://github.com/user-attachments/assets/70aab820-f821-4a40-8ae9-4dea74064a92">