### PR TITLE
Preserve qualified name of types on deprecation replacement

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/psi/Refactorings.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/Refactorings.kt
@@ -83,7 +83,12 @@ fun PklTypeName.replaceDeprecated(
   replacementType.acceptChildren(
     ReplacementVisitor(declImportList, usageImportList, null, null, project)
   )
-  replace(replacementType.typeName)
+  // if this type is qualified but the replacement isn't, replace just the last part
+  if (replacementType.typeName.moduleName != null) {
+    replace(replacementType.typeName)
+  } else {
+    simpleName.replace(replacementType.typeName.simpleName)
+  }
 
   return true
 }


### PR DESCRIPTION
This fixes a problem where deprecated imported types where replaced by their unqualified names, leading to wrong code:

```pkl
// @Deprecated { replaceWith = "ReplaceWith" }
// typealias Deprecated = String
import "foo.pkl"

// `foo.Deprecated` would be replaced with `ReplaceWith`, losing the qualifier
prop: foo.Deprecated
```