### PR TITLE
Remove import/read expression from warning suppression target

### DIFF
--- a/src/main/grammar/pkl.bnf
+++ b/src/main/grammar/pkl.bnf
@@ -625,9 +625,7 @@ importExpr ::= ('import' | 'import*') ('(' moduleUri ')' | moduleUri) {
   ]
 }
 
-readExpr ::= ('read' | 'read*' | 'read?') '(' expr ')' {
-  implements = "org.pkl.intellij.psi.PklSuppressWarningsTarget"
-}
+readExpr ::= ('read' | 'read*' | 'read?') '(' expr ')'
 
 functionLiteral ::= functionParameterList '->' expr {
   implements = "org.pkl.intellij.psi.PklParameterListOwner"

--- a/src/main/kotlin/org/pkl/intellij/psi/PklImportBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklImportBase.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,6 @@
  */
 package org.pkl.intellij.psi
 
-interface PklImportBase : PklElement, PklSuppressWarningsTarget {
+interface PklImportBase : PklElement {
   val moduleUri: PklModuleUri?
 }


### PR DESCRIPTION
This fixes a runtime assertion error.

Only import clauses make sense as warning suppression targets; the expression forms of these can be targeted by targeting their parent (e.g. the property that they are assigned to).