### PR TITLE
Fix parsing of import expressions

### DIFF
--- a/src/main/grammar/pkl.bnf
+++ b/src/main/grammar/pkl.bnf
@@ -618,7 +618,7 @@ letExpr ::= let '('? typedIdentifier '=' expr (')' | in) expr {
 
 throwExpr ::= throw '(' expr ')'
 traceExpr ::= trace '(' expr ')'
-importExpr ::= ('import' | 'import*') ('(' moduleUri ')' | moduleUri) {
+importExpr ::= ('import' | 'import*') '(' moduleUri ')' {
   implements = "org.pkl.intellij.psi.PklImportBase"
   methods = [
     moduleUri = "moduleUri"


### PR DESCRIPTION
Import expressions must be surrounded with parentheses.