### PR TITLE
Revert Fix subtype detection type constraint edge case (#104)

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/type/Types.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/Types.kt
@@ -572,31 +572,27 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
 
       if (typeArguments.isEmpty()) {
         assert(classType.typeArguments.isEmpty()) // holds for stdlib
-      } else {
-        val size = typeArguments.size
-        val otherSize = classType.typeArguments.size
-        assert(size >= otherSize) // holds for stdlib
-
-        for (i in 1..otherSize) {
-          // assume [typeArg] maps directly to [otherTypeArg] in extends clause(s) (holds for
-          // stdlib)
-          val typeArg = typeArguments[size - i]
-          val typeParam = typeParameters[size - i]
-          val otherTypeArg = classType.typeArguments[otherSize - i]
-          val isMatch =
-            when (typeParam.firstChildTokenType()) {
-              PklElementTypes.OUT -> typeArg.isSubtypeOf(otherTypeArg, base, context) // covariance
-              PklElementTypes.IN ->
-                otherTypeArg.isSubtypeOf(typeArg, base, context) // contravariance
-              else -> typeArg.isEquivalentTo(otherTypeArg, base, context) // invariance
-            }
-          if (!isMatch) return false
-        }
+        return true
       }
 
-      // this class is a subtype of classType iff classType's constraints are a subset of this
-      // class's constraints.
-      return constraints.containsAll(classType.constraints)
+      val size = typeArguments.size
+      val otherSize = classType.typeArguments.size
+      assert(size >= otherSize) // holds for stdlib
+
+      for (i in 1..otherSize) {
+        // assume [typeArg] maps directly to [otherTypeArg] in extends clause(s) (holds for stdlib)
+        val typeArg = typeArguments[size - i]
+        val typeParam = typeParameters[size - i]
+        val otherTypeArg = classType.typeArguments[otherSize - i]
+        val isMatch =
+          when (typeParam.firstChildTokenType()) {
+            PklElementTypes.OUT -> typeArg.isSubtypeOf(otherTypeArg, base, context) // covariance
+            PklElementTypes.IN -> otherTypeArg.isSubtypeOf(typeArg, base, context) // contravariance
+            else -> typeArg.isEquivalentTo(otherTypeArg, base, context) // invariance
+          }
+        if (!isMatch) return false
+      }
+      return true
     }
 
     override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =


### PR DESCRIPTION
The original fix in #104 was found to cause issues when type checking literal values assigned to properties with constrained types, eg.
```pkl
foo: Int(isBetween(1, 5)) = 4
```
This happened because the literal's type (`Int`) was not considered a subtype of the constrained property type.