### PR TITLE
Moved to automation in https://github.com/apple/pkl-project-commons/pull/17/files chore: restrict GitHub workflow permissions - future-proof

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: Build
+permissions:
+  contents: read
 'on':
   push:
     branches-ignore:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: Build (main)
+permissions:
+  contents: read
 'on':
   push:
     branches:

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -2,6 +2,8 @@
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: Pull Request
+permissions:
+  contents: read
 'on':
   pull_request: {}
 jobs:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -2,6 +2,8 @@
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: Build (release branch)
+permissions:
+  contents: read
 'on':
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: Release
+permissions:
+  contents: read
 'on':
   push:
     branches-ignore:

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -2,6 +2,8 @@
 # This file was generated from a template using https://github.com/StefMa/pkl-gha
 
 name: PR Test Reports
+permissions:
+  contents: read
 'on':
   workflow_run:
     types:


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167 for additional context

This approach aligns with security best practices, as detailed in the following documentation:

- https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/


The default GITHUB_TOKEN permissions are defined at the repository level. This PR modifies the workflow-level overrides to conform to OpenSSF best practices -> defense in depth.

Allow me to quote OpenSSF:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

> The highest score is awarded when the permissions definitions in each workflow's yaml file are set as read-only at the top level and the required write permissions are declared at the run-level.”

> Remediation steps
> - Set top-level permissions as read-all or contents: read as described in GitHub's documentation.
> - Set any required write permissions at the job-level. Only set the permissions required for that job; do not set permissions: write-all at the job level.


Compare to the LLVM project:

Top-level: contents read, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L3-L4 -> this makes it future-proof

Job-level: Allow write permissions as needed, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L53-L58
