### PR TITLE
Bump max allowed IntelliJ version to 253.*

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ intellijRunIde = "2024.3"
 intellijPlugin = "2.10.4"
 intellijSinceBuild = "243"
 # set to "999.*" to disable upper bound
-intellijUntilBuild = "252.*"
+intellijUntilBuild = "253.*"
 # Grammar-Kit isn't compatible with 1.7.0-2
 jflex = "1.7.0-1"
 junit = "4.13.2"

--- a/release/updatePlugins.xml
+++ b/release/updatePlugins.xml
@@ -4,7 +4,7 @@
       id="org.pkl-lang"
       url="https://github.com/apple/pkl-intellij/releases/download/#version#/pkl-intellij-#version#.zip" version="#version#"
   >
-    <idea-version since-build="243" until-build="252.*" />
+    <idea-version since-build="243" until-build="253.*" />
     <name>Pkl</name>
     <description><![CDATA[
 <p>


### PR DESCRIPTION
Which is the current EAP version: https://www.jetbrains.com/idea/nextversion/