### PR TITLE
Fix error due to potential conflict with Bazel plugin

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.psi
 
+import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.ProjectRootManager
@@ -437,7 +438,12 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
               if (targetUriStr.startsWith('/')) {
                 return findOnClassPath(sourcePsiFile, null, targetUriStr.drop(1))
               }
-              val sourceDir = sourceVirtualFile.parent
+              val sourceDir =
+                when (sourceVirtualFile) {
+                  is VirtualFileWindow -> sourceVirtualFile.parent
+                      ?: sourceVirtualFile.delegate.parent
+                  else -> sourceVirtualFile.parent
+                }
               if (sourceDir == sourceRoot) {
                 return findOnClassPath(sourcePsiFile, null, targetUriStr)
               }


### PR DESCRIPTION
Error:
```
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'dst' of 
com/intellij/openapi/vfs/VfsUtilCore.findRelativePath must not be null
```
At
```
org.pkl.intellij.psi.PklModuleUriReference$Companion.resolveVirtual(PklModuleUriReference.kt:445)
```

This one is fiddly to repro. I had a really hard time getting my `runIde` instance into this state. I was able to do it exactly once and then was not able to repeat it to verify this fix. State looks something like this:
* Have the IJ Bazel (not legacy) plugin installed
* Load a Bazel project
* The plugin may, under conditions I've not yet identified, create a "module" named `.workspace` with the same source root as the project's actual main module.
* Editing a Pkl code block inside a markdown file in the repo triggers the above error.
* `VirtualFile` (the type of `sourceVirtualFile`) provides no nullability annotation for `getParent()` so Kotlin sees the return type as `VirtualFile!` and doesn't warn about the `sourceDir` value potentially being null.
* In this particular case, `sourceVirtualFile` is a `VirtualFileWindow`, which returns null for `getParent()`.

The fix checks if `sourceVirtualFile` is a `VirtualFileWindow` and, if it is, calls `getDelegate().getParent()` when `getParent()` returns null.

Unfortunately, because this state is so hard to get into, I'm not able to verify if this fix works as intended or is complete.