### PR TITLE
Skip read-only project dirs during pkl project resolve

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
@@ -30,6 +30,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.messages.Topic
 import com.jetbrains.rd.util.concurrentMapOf
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicLong
 import org.jdom.Element
@@ -130,7 +131,20 @@ class PklProjectService(private val project: Project) :
         project.messageBus.syncPublisher(PKL_PROJECTS_TOPIC).pklProjectsUpdated(this, pklProjects)
         return@runBackgroundableTask
       }
-      project.pklCli.resolveProject(pklProjectFiles.map { it.parent.toNioPath() })
+      // Only resolve projects in writable directories.
+      // Read-only paths (e.g. Nix flake inputs under .direnv) cannot receive the generated
+      // PklProject.deps.json file, so we skip them rather than crashing the entire sync.
+      val writableProjectDirs =
+        pklProjectFiles.map { it.parent.toNioPath() }.filter { Files.isWritable(it) }
+      val skippedCount = pklProjectFiles.size - writableProjectDirs.size
+      if (skippedCount > 0) {
+        LOG.warn(
+          "$skippedCount PklProject file(s) skipped during resolve: their parent directories are read-only"
+        )
+      }
+      if (writableProjectDirs.isNotEmpty()) {
+        project.pklCli.resolveProject(writableProjectDirs)
+      }
       val metadatas =
         getProjectMetadatas(pklProjectFiles).map { metadata ->
           val projectFile = localFs.findFileByNioFile(Path.of(URI(metadata.projectFileUri)))!!


### PR DESCRIPTION
## Problem

When using direnv with a Nix flake, `pkl project resolve` fails with
`Permission denied`. Nix flake inputs are fetched into `.direnv/` as
read-only paths. The plugin discovers `PklProject` files inside those
paths and attempts to write the generated `PklProject.deps.json` there,
which crashes the entire sync.

## Solution

Filter out non-writable project directories before passing them to
`resolveProject`. The metadata evaluation (`getProjectMetadatas`) still
runs for all discovered projects since it only reads files. A missing
`deps.json` is already handled gracefully — `resolvedDeps` becomes null.
A `WARN` log entry is emitted for each skipped directory so the user can
see what was filtered.

## Steps to reproduce

1. Have a Nix flake-based project that uses direnv.
2. Open it in IntelliJ with the Pkl plugin.
3. The `.direnv/` directory contains read-only Nix store paths that
   include `PklProject` files.
4. Sync fails with `Permission denied`.

After this fix, the sync completes and only writable projects are
resolved.

---

By submitting this pull request, I acknowledge that I have the right to
license my contribution to Apple and the community, and agree that my
contribution is licensed under the Apache 2.0 license.