### PR TITLE
Fix IncorrectOperationException and support smart URI rewriting on file move

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
@@ -15,6 +15,8 @@
  */
 package org.pkl.intellij.packages
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.*
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.externalSystem.autoimport.ExternalSystemProjectTracker
@@ -153,6 +155,11 @@ class PklProjectService(private val project: Project) :
       modificationCount.getAndIncrement()
       project.messageBus.syncPublisher(PKL_PROJECTS_SYNC_TOPIC).pklProjectSyncFinished()
       project.messageBus.syncPublisher(PKL_PROJECTS_TOPIC).pklProjectsUpdated(this, pklProjects)
+      // Re-run annotators on all open editors so that @dep/path imports that were just resolved
+      // (or whose dependency was just added to a PklProject file) stop showing warnings.
+      ApplicationManager.getApplication().invokeLater {
+        DaemonCodeAnalyzer.getInstance(project).restart()
+      }
     }
 
   fun getPklProject(file: VirtualFile): PklProject? =

--- a/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
+++ b/src/main/kotlin/org/pkl/intellij/packages/PklProjectService.kt
@@ -155,8 +155,6 @@ class PklProjectService(private val project: Project) :
       modificationCount.getAndIncrement()
       project.messageBus.syncPublisher(PKL_PROJECTS_SYNC_TOPIC).pklProjectSyncFinished()
       project.messageBus.syncPublisher(PKL_PROJECTS_TOPIC).pklProjectsUpdated(this, pklProjects)
-      // Re-run annotators on all open editors so that @dep/path imports that were just resolved
-      // (or whose dependency was just added to a PklProject file) stop showing warnings.
       ApplicationManager.getApplication().invokeLater {
         DaemonCodeAnalyzer.getInstance(project).restart()
       }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleNameReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleNameReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleNameReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleNameReference.kt
@@ -17,7 +17,6 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
-import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 
 class PklModuleNameReference(private val moduleName: PklModuleName) :
@@ -41,6 +40,5 @@ class PklModuleNameReference(private val moduleName: PklModuleName) :
 
   override fun resolve(): PklModule? = resolveContextual(null)
 
-  @Throws(IncorrectOperationException::class)
   override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleNameReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleNameReference.kt
@@ -17,6 +17,7 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
+import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 
 class PklModuleNameReference(private val moduleName: PklModuleName) :
@@ -39,4 +40,7 @@ class PklModuleNameReference(private val moduleName: PklModuleName) :
   }
 
   override fun resolve(): PklModule? = resolveContextual(null)
+
+  @Throws(IncorrectOperationException::class)
+  override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleReference.kt
@@ -19,7 +19,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.ElementManipulators
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReferenceBase
-import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 
 class PklModuleReference(source: PklElement) : PsiReferenceBase<PklElement>(source), PklReference {
@@ -30,6 +29,5 @@ class PklModuleReference(source: PklElement) : PsiReferenceBase<PklElement>(sour
 
   override fun resolveContextual(context: PklProject?): PklElement? = resolve()
 
-  @Throws(IncorrectOperationException::class)
   override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleReference.kt
@@ -17,7 +17,9 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.ElementManipulators
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReferenceBase
+import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 
 class PklModuleReference(source: PklElement) : PsiReferenceBase<PklElement>(source), PklReference {
@@ -27,4 +29,7 @@ class PklModuleReference(source: PklElement) : PsiReferenceBase<PklElement>(sour
   override fun resolve(): PklElement? = myElement.enclosingModule
 
   override fun resolveContextual(context: PklProject?): PklElement? = resolve()
+
+  @Throws(IncorrectOperationException::class)
+  override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -191,32 +191,15 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
 
       if (relPath != null) {
-        // Strategy 1: find an already-declared dependency whose root matches the target project.
-        val sourceDeps =
-          element.enclosingModule?.dependencies(null)
-            ?: sourcePklProjectDir?.let { srcDir ->
-              ideaProject.pklProjectService.pklProjects.values
-                .find { it.projectDirVirtualFile?.url == srcDir.url }
-                ?.myDependencies
-            }
-
+        // Strategy 1: if the source module already declares a dependency whose root matches the
+        // target project, reuse that dep name without touching any files.
         val declaredDepName =
-          sourceDeps?.entries?.find { (_, dep) ->
-            dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
-          }?.key
-
+          findDeclaredDepName(sourcePklProjectDir, targetPklProjectDir, ideaProject)
         if (declaredDepName != null) return "@$declaredDepName/$relPath"
 
-        // Strategy 2: target has a package identity — derive the name and add the dependency
-        // declaration to the source PklProject file if it is not there already.
-        val targetPackageName =
-          ideaProject.pklProjectService.pklProjects.values
-            .find { it.projectDirVirtualFile?.url == targetPklProjectDir.url }
-            ?.metadata?.packageUri?.path
-            ?.substringBeforeLast('@')
-            ?.substringAfterLast('/')
-            ?.takeIf { it.isNotEmpty() }
-
+        // Strategy 2: derive the dep name from the target project's packageUri, add the entry to
+        // the source PklProject file if it is not already there, and return the @dep/path URI.
+        val targetPackageName = findTargetPackageName(targetPklProjectDir, ideaProject)
         if (targetPackageName != null && sourcePklProjectDir != null) {
           addDependencyToPklProject(
             sourcePklProjectDir, targetPklProjectDir, targetPackageName, ideaProject
@@ -239,9 +222,51 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   }
 
   /**
+   * Returns the name of an already-declared dependency in the source module (or its PklProject)
+   * whose resolved root equals [targetPklProjectDir], or `null` if none is found.
+   *
+   * Checks the in-memory module dependencies first; falls back to the project-level metadata so
+   * that the lookup works even when the source file has not been fully loaded yet.
+   */
+  private fun findDeclaredDepName(
+    sourcePklProjectDir: VirtualFile?,
+    targetPklProjectDir: VirtualFile,
+    ideaProject: Project
+  ): String? {
+    val sourceDeps =
+      element.enclosingModule?.dependencies(null)
+        ?: sourcePklProjectDir?.let { srcDir ->
+          ideaProject.pklProjectService.pklProjects.values
+            .find { it.projectDirVirtualFile?.url == srcDir.url }
+            ?.myDependencies
+        }
+    return sourceDeps?.entries?.find { (_, dep) ->
+      dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
+    }?.key
+  }
+
+  /**
+   * Derives the dependency name for [targetPklProjectDir] from its project's `packageUri`
+   * (e.g. `package://localhost:0/myLib@1.0.0` → `"myLib"`), or returns `null` if the target
+   * project has no `packageUri` or the name cannot be extracted.
+   */
+  private fun findTargetPackageName(
+    targetPklProjectDir: VirtualFile,
+    ideaProject: Project
+  ): String? =
+    ideaProject.pklProjectService.pklProjects.values
+      .find { it.projectDirVirtualFile?.url == targetPklProjectDir.url }
+      ?.metadata?.packageUri?.path
+      ?.substringBeforeLast('@')
+      ?.substringAfterLast('/')
+      ?.takeIf { it.isNotEmpty() }
+
+  /**
    * Adds `["depName"] = import("relPath/PklProject")` to the `dependencies` block of the
    * `PklProject` file in [sourcePklProjectDir]. Creates the `dependencies` block if absent.
    * Does nothing if the entry is already present.
+   *
+   * After editing the document, schedules a PKL project sync via [scheduleSyncIfNeeded].
    */
   private fun addDependencyToPklProject(
     sourcePklProjectDir: VirtualFile,
@@ -275,16 +300,21 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       document.insertString(document.textLength, "\ndependencies {\n$newEntry}\n")
     }
 
-    // Schedule a PKL project sync (pkl project resolve → PklProject.deps.json) to run after
-    // the current write action completes. A project-level flag prevents multiple syncs when
-    // several references are updated in a single refactoring pass.
-    if (ideaProject.getUserData(SYNC_SCHEDULED_KEY) != true) {
-      ideaProject.putUserData(SYNC_SCHEDULED_KEY, true)
-      ApplicationManager.getApplication().invokeLater {
-        ideaProject.putUserData(SYNC_SCHEDULED_KEY, null)
-        FileDocumentManager.getInstance().saveAllDocuments()
-        ideaProject.pklProjectService.syncProjects()
-      }
+    scheduleSyncIfNeeded(ideaProject)
+  }
+
+  /**
+   * Schedules a PKL project sync (pkl project resolve → PklProject.deps.json) to run after the
+   * current write action completes. A project-level flag ([SYNC_SCHEDULED_KEY]) prevents multiple
+   * syncs when several references are updated in a single refactoring pass.
+   */
+  private fun scheduleSyncIfNeeded(ideaProject: Project) {
+    if (ideaProject.getUserData(SYNC_SCHEDULED_KEY) == true) return
+    ideaProject.putUserData(SYNC_SCHEDULED_KEY, true)
+    ApplicationManager.getApplication().invokeLater {
+      ideaProject.putUserData(SYNC_SCHEDULED_KEY, null)
+      FileDocumentManager.getInstance().saveAllDocuments()
+      ideaProject.pklProjectService.syncProjects()
     }
   }
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -168,9 +168,16 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   /**
    * Returns the best URI string for a relative import after [targetFile] has moved.
    *
-   * When [sourceFile] is outside the PKL project that contains [targetFile] and the source
-   * module's resolved dependencies include that project as a local dependency, returns
-   * `@<depName>/<relPath>`. Otherwise returns a plain filesystem-relative path.
+   * When [sourceFile] is outside the PKL project that contains [targetFile], attempts to produce
+   * an `@<depName>/<relPath>` URI using the following resolution order:
+   *
+   * 1. Search the source module's resolved dependencies for one whose root matches the target
+   *    project directory (handles the case where the dep is already declared).
+   * 2. Find the target project's own `package.name` via [pklProjectService] (handles the case
+   *    where the dep is not yet declared but the target has a package identity — the user still
+   *    needs to add the dependency declaration to their PklProject).
+   *
+   * Falls back to a plain filesystem-relative path if neither strategy yields a name.
    *
    * Returns `null` if a path cannot be computed at all (e.g. no common ancestor).
    */
@@ -186,28 +193,38 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       // Only attempt @dep/path when source is outside the target's PKL project.
       // Compare by URL string to avoid VirtualFile identity mismatches.
       if (sourcePklProjectDir?.url != targetPklProjectDir.url) {
-        // Primary: use the enclosing module's resolved dependencies. This works for both
-        // PKL project files and files inside packages, and goes through the same resolution
-        // path used by the rest of the plugin.
-        val sourceDeps =
-          element.enclosingModule?.dependencies(null)
-          // Fallback: search all known PKL projects by URL in case the module is not available.
-            ?: sourcePklProjectDir?.let { srcDir ->
-              ideaProject.pklProjectService.pklProjects.values
-                .find { it.projectDirVirtualFile?.url == srcDir.url }
-                ?.myDependencies
-            }
+        val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
 
-        // Match by URL string instead of VirtualFile identity to handle path-canonicalization
-        // differences (e.g. symlinks, findFileByRelativePath with ".." vs walking up).
-        val depName =
-          sourceDeps?.entries?.find { (_, dep) ->
-            dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
-          }?.key
+        if (relPath != null) {
+          // Strategy 1: find a declared dependency in the source module whose root matches.
+          // Uses enclosing module's resolved deps so it works for both packages and projects.
+          val sourceDeps =
+            element.enclosingModule?.dependencies(null)
+              ?: sourcePklProjectDir?.let { srcDir ->
+                ideaProject.pklProjectService.pklProjects.values
+                  .find { it.projectDirVirtualFile?.url == srcDir.url }
+                  ?.myDependencies
+              }
 
-        if (depName != null) {
-          val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
-          if (relPath != null) return "@$depName/$relPath"
+          val declaredDepName =
+            sourceDeps?.entries?.find { (_, dep) ->
+              dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
+            }?.key
+
+          if (declaredDepName != null) return "@$declaredDepName/$relPath"
+
+          // Strategy 2: the source project hasn't declared the dep yet, but the target
+          // project has a package name we can derive from its packageUri.
+          // e.g. package://localhost:0/tests@1.0.0  →  name = "tests"
+          val targetPackageName =
+            ideaProject.pklProjectService.pklProjects.values
+              .find { it.projectDirVirtualFile?.url == targetPklProjectDir.url }
+              ?.metadata?.packageUri?.path
+              ?.substringBeforeLast('@')
+              ?.substringAfterLast('/')
+              ?.takeIf { it.isNotEmpty() }
+
+          if (targetPackageName != null) return "@$targetPackageName/$relPath"
         }
       }
     }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.vfs.*
 import com.intellij.openapi.vfs.impl.http.HttpVirtualFile
 import com.intellij.openapi.vfs.impl.http.RemoteFileState
 import com.intellij.psi.*
+import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.ParameterizedCachedValueProvider
@@ -119,6 +120,45 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       )
     val newContent = PklPsiFactory.createStringContent(newText, stringStart.text, element.project)
     stringContent.node.replaceAllChildrenToChildrenOf(newContent.node)
+    return element
+  }
+
+  /**
+   * Called by IntelliJ's refactoring engine when a referenced file/directory is moved.
+   * Recomputes the URI to point at [newTarget]'s new location.
+   *
+   * Only relative-path and `file:` URIs are updated; other schemes (pkl:, package:, https:, etc.)
+   * are unaffected by file moves and are left as-is.
+   */
+  @Throws(IncorrectOperationException::class)
+  override fun bindToElement(newTarget: PsiElement): PsiElement {
+    val targetVirtualFile =
+      when (newTarget) {
+        is PsiFile -> newTarget.virtualFile
+        is PsiDirectory -> newTarget.virtualFile
+        else -> null
+      } ?: return element
+
+    val sourceVirtualFile = element.containingFile.originalFile.virtualFile ?: return element
+    val currentUri = element.stringConstant.content.text
+
+    val newUri =
+      when {
+        // Absolute file: URI — replace with the new absolute VFS URL.
+        currentUri.startsWith("file:", ignoreCase = true) -> targetVirtualFile.url
+        // Relative URI (no scheme) — recompute the relative path from source dir to new target.
+        !currentUri.contains(':') -> {
+          val sourceDir = sourceVirtualFile.parent ?: return element
+          VfsUtilCore.findRelativePath(sourceDir, targetVirtualFile, '/') ?: return element
+        }
+        // modulepath:, package:, pkl:, https: — not affected by moves; skip.
+        else -> return element
+      }
+
+    val stringConstant = element.stringConstant
+    val newContent =
+      PklPsiFactory.createStringContent(newUri, stringConstant.stringStart.text, element.project)
+    stringConstant.content.node.replaceAllChildrenToChildrenOf(newContent.node)
     return element
   }
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +28,11 @@ import com.intellij.openapi.vfs.*
 import com.intellij.openapi.vfs.impl.http.HttpVirtualFile
 import com.intellij.openapi.vfs.impl.http.RemoteFileState
 import com.intellij.psi.*
-import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.ParameterizedCachedValueProvider
 import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.util.IncorrectOperationException
 import java.net.URI
 import java.net.URISyntaxException
 import org.pkl.intellij.PklLanguage
@@ -127,9 +127,8 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   }
 
   /**
-   * Called by IntelliJ's refactoring engine when a referenced file/directory is moved.
-   * Recomputes the URI to point at [newTarget]'s new location.
-   *
+   * Called by IntelliJ's refactoring engine when a referenced file/directory is moved. Recomputes
+   * the URI to point at [newTarget]'s new location.
    * - For `file:` URIs: replaces with the new absolute VFS URL.
    * - For relative URIs: if the source file is **outside** the PKL project that owns the moved
    *   file, and the source's PKL project declares that project as a local dependency, the URI is
@@ -144,7 +143,8 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
         is PsiFile -> newTarget.virtualFile
         is PsiDirectory -> newTarget.virtualFile
         else -> null
-      } ?: return element
+      }
+        ?: return element
 
     val sourceVirtualFile = element.containingFile.originalFile.virtualFile ?: return element
     val currentUri = element.stringConstant.content.text
@@ -154,8 +154,8 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
         // Absolute file: URI — replace with the new absolute VFS URL.
         currentUri.startsWith("file:", ignoreCase = true) -> targetVirtualFile.url
         // Relative URI (no scheme) — prefer @dep/path when crossing project boundaries.
-        !currentUri.contains(':') ->
-          computeNewRelativeUri(sourceVirtualFile, targetVirtualFile) ?: return element
+        !currentUri.contains(':') -> computeNewRelativeUri(sourceVirtualFile, targetVirtualFile)
+            ?: return element
         // modulepath:, package:, pkl:, https: — not affected by moves; skip.
         else -> return element
       }
@@ -172,7 +172,6 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
    * auto-declares the dependency in the source `PklProject` file when needed.
    *
    * Resolution order when [sourceFile] is outside the target's PKL project:
-   *
    * 1. **Declared dep** — search the source module's resolved dependencies for one whose root
    *    matches the target project directory. Returns `@<depName>/<relPath>` immediately.
    * 2. **Package name** — derive the dep name from the target project's `packageUri` (e.g.
@@ -202,7 +201,10 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
         val targetPackageName = findTargetPackageName(targetPklProjectDir, ideaProject)
         if (targetPackageName != null && sourcePklProjectDir != null) {
           addDependencyToPklProject(
-            sourcePklProjectDir, targetPklProjectDir, targetPackageName, ideaProject
+            sourcePklProjectDir,
+            targetPklProjectDir,
+            targetPackageName,
+            ideaProject
           )
           return "@$targetPackageName/$relPath"
         }
@@ -240,15 +242,16 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
             .find { it.projectDirVirtualFile?.url == srcDir.url }
             ?.myDependencies
         }
-    return sourceDeps?.entries?.find { (_, dep) ->
-      dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
-    }?.key
+    return sourceDeps
+      ?.entries
+      ?.find { (_, dep) -> dep.getRoot(ideaProject)?.url == targetPklProjectDir.url }
+      ?.key
   }
 
   /**
-   * Derives the dependency name for [targetPklProjectDir] from its project's `packageUri`
-   * (e.g. `package://localhost:0/myLib@1.0.0` → `"myLib"`), or returns `null` if the target
-   * project has no `packageUri` or the name cannot be extracted.
+   * Derives the dependency name for [targetPklProjectDir] from its project's `packageUri` (e.g.
+   * `package://localhost:0/myLib@1.0.0` → `"myLib"`), or returns `null` if the target project has
+   * no `packageUri` or the name cannot be extracted.
    */
   private fun findTargetPackageName(
     targetPklProjectDir: VirtualFile,
@@ -256,15 +259,17 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   ): String? =
     ideaProject.pklProjectService.pklProjects.values
       .find { it.projectDirVirtualFile?.url == targetPklProjectDir.url }
-      ?.metadata?.packageUri?.path
+      ?.metadata
+      ?.packageUri
+      ?.path
       ?.substringBeforeLast('@')
       ?.substringAfterLast('/')
       ?.takeIf { it.isNotEmpty() }
 
   /**
    * Adds `["depName"] = import("relPath/PklProject")` to the `dependencies` block of the
-   * `PklProject` file in [sourcePklProjectDir]. Creates the `dependencies` block if absent.
-   * Does nothing if the entry is already present.
+   * `PklProject` file in [sourcePklProjectDir]. Creates the `dependencies` block if absent. Does
+   * nothing if the entry is already present.
    *
    * After editing the document, schedules a PKL project sync via [scheduleSyncIfNeeded].
    */
@@ -320,8 +325,8 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
 
   companion object {
     /**
-     * Project-level flag used to ensure at most one PKL project sync is scheduled per
-     * refactoring operation (even when multiple references are updated in one pass).
+     * Project-level flag used to ensure at most one PKL project sync is scheduled per refactoring
+     * operation (even when multiple references are updated in one pass).
      */
     private val SYNC_SCHEDULED_KEY = Key.create<Boolean>("pkl.depSync.scheduled")
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -168,9 +168,9 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   /**
    * Returns the best URI string for a relative import after [targetFile] has moved.
    *
-   * When [sourceFile] is outside the PKL project that contains [targetFile] and the source's own
-   * PKL project declares that project as a local dependency, returns `@<depName>/<relPath>`.
-   * Otherwise returns a plain filesystem-relative path.
+   * When [sourceFile] is outside the PKL project that contains [targetFile] and the source
+   * module's resolved dependencies include that project as a local dependency, returns
+   * `@<depName>/<relPath>`. Otherwise returns a plain filesystem-relative path.
    *
    * Returns `null` if a path cannot be computed at all (e.g. no common ancestor).
    */
@@ -183,15 +183,26 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
     if (targetPklProjectDir != null) {
       val sourcePklProjectDir = findPklProjectDir(sourceFile)
 
-      // Source is in a different (or absent) PKL project than the moved file.
-      if (sourcePklProjectDir != targetPklProjectDir) {
-        val sourcePklProject =
-          sourcePklProjectDir?.let { ideaProject.pklProjectService.getPklProject(it) }
+      // Only attempt @dep/path when source is outside the target's PKL project.
+      // Compare by URL string to avoid VirtualFile identity mismatches.
+      if (sourcePklProjectDir?.url != targetPklProjectDir.url) {
+        // Primary: use the enclosing module's resolved dependencies. This works for both
+        // PKL project files and files inside packages, and goes through the same resolution
+        // path used by the rest of the plugin.
+        val sourceDeps =
+          element.enclosingModule?.dependencies(null)
+          // Fallback: search all known PKL projects by URL in case the module is not available.
+            ?: sourcePklProjectDir?.let { srcDir ->
+              ideaProject.pklProjectService.pklProjects.values
+                .find { it.projectDirVirtualFile?.url == srcDir.url }
+                ?.myDependencies
+            }
 
-        // Search source project's local dependencies for one whose root is the target project.
+        // Match by URL string instead of VirtualFile identity to handle path-canonicalization
+        // differences (e.g. symlinks, findFileByRelativePath with ".." vs walking up).
         val depName =
-          sourcePklProject?.myDependencies?.entries?.find { (_, dep) ->
-            dep.getRoot(ideaProject) == targetPklProjectDir
+          sourceDeps?.entries?.find { (_, dep) ->
+            dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
           }?.key
 
         if (depName != null) {

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -151,12 +151,9 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
 
     val newUri =
       when {
-        // Absolute file: URI — replace with the new absolute VFS URL.
         currentUri.startsWith("file:", ignoreCase = true) -> targetVirtualFile.url
-        // Relative URI (no scheme) — prefer @dep/path when crossing project boundaries.
         !currentUri.contains(':') -> computeNewRelativeUri(sourceVirtualFile, targetVirtualFile)
             ?: return element
-        // modulepath:, package:, pkl:, https: — not affected by moves; skip.
         else -> return element
       }
 
@@ -190,14 +187,10 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
 
       if (relPath != null) {
-        // Strategy 1: if the source module already declares a dependency whose root matches the
-        // target project, reuse that dep name without touching any files.
         val declaredDepName =
           findDeclaredDepName(sourcePklProjectDir, targetPklProjectDir, ideaProject)
         if (declaredDepName != null) return "@$declaredDepName/$relPath"
 
-        // Strategy 2: derive the dep name from the target project's packageUri, add the entry to
-        // the source PklProject file if it is not already there, and return the @dep/path URI.
         val targetPackageName = findTargetPackageName(targetPklProjectDir, ideaProject)
         if (targetPackageName != null && sourcePklProjectDir != null) {
           addDependencyToPklProject(
@@ -211,7 +204,6 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       }
     }
 
-    // Fall back to a relative path only when there is no PKL project context on either side.
     if (targetPklProjectDir == null || sourcePklProjectDir == null) {
       val sourceDir = sourceFile.parent ?: return null
       return VfsUtilCore.findRelativePath(sourceDir, targetFile, '/')
@@ -281,7 +273,6 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   ) {
     val pklProjectVFile = sourcePklProjectDir.findChild(PKL_PROJECT_FILENAME) ?: return
 
-    // Relative path from the source project's directory to the target PklProject file.
     val relToTarget =
       VfsUtilCore.findRelativePath(sourcePklProjectDir, targetPklProjectDir, '/') ?: return
     val importPath = "$relToTarget/$PKL_PROJECT_FILENAME"
@@ -290,18 +281,15 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       PsiManager.getInstance(ideaProject).findFile(pklProjectVFile) as? PklModule ?: return
     val depsProperty = pklModule.properties.find { it.name == "dependencies" }
 
-    // Skip if this dep name is already present (avoids duplicate entries).
     if (depsProperty?.text?.contains("[\"$depName\"]") == true) return
 
     val document = FileDocumentManager.getInstance().getDocument(pklProjectVFile) ?: return
     val newEntry = "  [\"$depName\"] = import(\"$importPath\")\n"
 
     if (depsProperty != null) {
-      // Insert before the closing `}` of the existing dependencies block.
       val objectBody = depsProperty.objectBodyList.firstOrNull() ?: return
       document.insertString(objectBody.textRange.endOffset - 1, newEntry)
     } else {
-      // Append a brand-new dependencies block at the end of the file.
       document.insertString(document.textLength, "\ndependencies {\n$newEntry}\n")
     }
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -35,6 +35,7 @@ import java.net.URI
 import java.net.URISyntaxException
 import org.pkl.intellij.PklLanguage
 import org.pkl.intellij.cacheKeyService
+import org.pkl.intellij.packages.PklProjectService.Companion.PKL_PROJECT_FILENAME
 import org.pkl.intellij.packages.dto.PackageUri
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.packages.pklProjectService
@@ -127,8 +128,12 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
    * Called by IntelliJ's refactoring engine when a referenced file/directory is moved.
    * Recomputes the URI to point at [newTarget]'s new location.
    *
-   * Only relative-path and `file:` URIs are updated; other schemes (pkl:, package:, https:, etc.)
-   * are unaffected by file moves and are left as-is.
+   * - For `file:` URIs: replaces with the new absolute VFS URL.
+   * - For relative URIs: if the source file is **outside** the PKL project that owns the moved
+   *   file, and the source's PKL project declares that project as a local dependency, the URI is
+   *   rewritten as `@<depName>/<path-from-dep-root>`. Otherwise falls back to a plain relative
+   *   path.
+   * - Other schemes (`pkl:`, `package:`, `https:`, `modulepath:`) are unaffected by file moves.
    */
   @Throws(IncorrectOperationException::class)
   override fun bindToElement(newTarget: PsiElement): PsiElement {
@@ -146,11 +151,9 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       when {
         // Absolute file: URI — replace with the new absolute VFS URL.
         currentUri.startsWith("file:", ignoreCase = true) -> targetVirtualFile.url
-        // Relative URI (no scheme) — recompute the relative path from source dir to new target.
-        !currentUri.contains(':') -> {
-          val sourceDir = sourceVirtualFile.parent ?: return element
-          VfsUtilCore.findRelativePath(sourceDir, targetVirtualFile, '/') ?: return element
-        }
+        // Relative URI (no scheme) — prefer @dep/path when crossing project boundaries.
+        !currentUri.contains(':') ->
+          computeNewRelativeUri(sourceVirtualFile, targetVirtualFile) ?: return element
         // modulepath:, package:, pkl:, https: — not affected by moves; skip.
         else -> return element
       }
@@ -162,7 +165,61 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
     return element
   }
 
+  /**
+   * Returns the best URI string for a relative import after [targetFile] has moved.
+   *
+   * When [sourceFile] is outside the PKL project that contains [targetFile] and the source's own
+   * PKL project declares that project as a local dependency, returns `@<depName>/<relPath>`.
+   * Otherwise returns a plain filesystem-relative path.
+   *
+   * Returns `null` if a path cannot be computed at all (e.g. no common ancestor).
+   */
+  private fun computeNewRelativeUri(sourceFile: VirtualFile, targetFile: VirtualFile): String? {
+    val ideaProject = element.project
+
+    // Find the PKL project dir of the moved (target) file.
+    val targetPklProjectDir = findPklProjectDir(targetFile)
+
+    if (targetPklProjectDir != null) {
+      val sourcePklProjectDir = findPklProjectDir(sourceFile)
+
+      // Source is in a different (or absent) PKL project than the moved file.
+      if (sourcePklProjectDir != targetPklProjectDir) {
+        val sourcePklProject =
+          sourcePklProjectDir?.let { ideaProject.pklProjectService.getPklProject(it) }
+
+        // Search source project's local dependencies for one whose root is the target project.
+        val depName =
+          sourcePklProject?.myDependencies?.entries?.find { (_, dep) ->
+            dep.getRoot(ideaProject) == targetPklProjectDir
+          }?.key
+
+        if (depName != null) {
+          val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
+          if (relPath != null) return "@$depName/$relPath"
+        }
+      }
+    }
+
+    // Default: plain relative path from the source file's directory.
+    val sourceDir = sourceFile.parent ?: return null
+    return VfsUtilCore.findRelativePath(sourceDir, targetFile, '/')
+  }
+
   companion object {
+    /**
+     * Walks up the directory tree from [file] and returns the first ancestor directory that
+     * contains a `PklProject` file, or `null` if none is found.
+     */
+    fun findPklProjectDir(file: VirtualFile): VirtualFile? {
+      var dir = if (file.isDirectory) file else file.parent
+      while (dir != null) {
+        if (dir.findChild(PKL_PROJECT_FILENAME) != null) return dir
+        dir = dir.parent
+      }
+      return null
+    }
+
     /**
      * [targetUri] is the prefix of [moduleUri] that this reference refers to. For URIs with a
      * single reference, `targetUri == moduleUri`. See [PklModuleUriBase] for which URIs have one

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.psi
 
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.ProjectRootManager
@@ -166,72 +167,112 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   }
 
   /**
-   * Returns the best URI string for a relative import after [targetFile] has moved.
+   * Returns the best URI string for a relative import after [targetFile] has moved, and
+   * auto-declares the dependency in the source `PklProject` file when needed.
    *
-   * When [sourceFile] is outside the PKL project that contains [targetFile], attempts to produce
-   * an `@<depName>/<relPath>` URI using the following resolution order:
+   * Resolution order when [sourceFile] is outside the target's PKL project:
    *
-   * 1. Search the source module's resolved dependencies for one whose root matches the target
-   *    project directory (handles the case where the dep is already declared).
-   * 2. Find the target project's own `package.name` via [pklProjectService] (handles the case
-   *    where the dep is not yet declared but the target has a package identity — the user still
-   *    needs to add the dependency declaration to their PklProject).
+   * 1. **Declared dep** — search the source module's resolved dependencies for one whose root
+   *    matches the target project directory. Returns `@<depName>/<relPath>` immediately.
+   * 2. **Package name** — derive the dep name from the target project's `packageUri` (e.g.
+   *    `package://localhost:0/tests@1.0.0` → `"tests"`), write the new dependency entry into the
+   *    source `PklProject` file (unless it already contains it), and return `@<name>/<relPath>`.
    *
-   * Falls back to a plain filesystem-relative path if neither strategy yields a name.
-   *
-   * Returns `null` if a path cannot be computed at all (e.g. no common ancestor).
+   * Falls back to a plain filesystem-relative path only when neither file has a `PklProject`
+   * ancestor (no PKL project context at all). Returns `null` if no path can be computed.
    */
   private fun computeNewRelativeUri(sourceFile: VirtualFile, targetFile: VirtualFile): String? {
     val ideaProject = element.project
-
-    // Find the PKL project dir of the moved (target) file.
     val targetPklProjectDir = findPklProjectDir(targetFile)
+    val sourcePklProjectDir = findPklProjectDir(sourceFile)
 
-    if (targetPklProjectDir != null) {
-      val sourcePklProjectDir = findPklProjectDir(sourceFile)
+    if (targetPklProjectDir != null && sourcePklProjectDir?.url != targetPklProjectDir.url) {
+      val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
 
-      // Only attempt @dep/path when source is outside the target's PKL project.
-      // Compare by URL string to avoid VirtualFile identity mismatches.
-      if (sourcePklProjectDir?.url != targetPklProjectDir.url) {
-        val relPath = VfsUtilCore.findRelativePath(targetPklProjectDir, targetFile, '/')
+      if (relPath != null) {
+        // Strategy 1: find an already-declared dependency whose root matches the target project.
+        val sourceDeps =
+          element.enclosingModule?.dependencies(null)
+            ?: sourcePklProjectDir?.let { srcDir ->
+              ideaProject.pklProjectService.pklProjects.values
+                .find { it.projectDirVirtualFile?.url == srcDir.url }
+                ?.myDependencies
+            }
 
-        if (relPath != null) {
-          // Strategy 1: find a declared dependency in the source module whose root matches.
-          // Uses enclosing module's resolved deps so it works for both packages and projects.
-          val sourceDeps =
-            element.enclosingModule?.dependencies(null)
-              ?: sourcePklProjectDir?.let { srcDir ->
-                ideaProject.pklProjectService.pklProjects.values
-                  .find { it.projectDirVirtualFile?.url == srcDir.url }
-                  ?.myDependencies
-              }
+        val declaredDepName =
+          sourceDeps?.entries?.find { (_, dep) ->
+            dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
+          }?.key
 
-          val declaredDepName =
-            sourceDeps?.entries?.find { (_, dep) ->
-              dep.getRoot(ideaProject)?.url == targetPklProjectDir.url
-            }?.key
+        if (declaredDepName != null) return "@$declaredDepName/$relPath"
 
-          if (declaredDepName != null) return "@$declaredDepName/$relPath"
+        // Strategy 2: target has a package identity — derive the name and add the dependency
+        // declaration to the source PklProject file if it is not there already.
+        val targetPackageName =
+          ideaProject.pklProjectService.pklProjects.values
+            .find { it.projectDirVirtualFile?.url == targetPklProjectDir.url }
+            ?.metadata?.packageUri?.path
+            ?.substringBeforeLast('@')
+            ?.substringAfterLast('/')
+            ?.takeIf { it.isNotEmpty() }
 
-          // Strategy 2: the source project hasn't declared the dep yet, but the target
-          // project has a package name we can derive from its packageUri.
-          // e.g. package://localhost:0/tests@1.0.0  →  name = "tests"
-          val targetPackageName =
-            ideaProject.pklProjectService.pklProjects.values
-              .find { it.projectDirVirtualFile?.url == targetPklProjectDir.url }
-              ?.metadata?.packageUri?.path
-              ?.substringBeforeLast('@')
-              ?.substringAfterLast('/')
-              ?.takeIf { it.isNotEmpty() }
-
-          if (targetPackageName != null) return "@$targetPackageName/$relPath"
+        if (targetPackageName != null && sourcePklProjectDir != null) {
+          addDependencyToPklProject(
+            sourcePklProjectDir, targetPklProjectDir, targetPackageName, ideaProject
+          )
+          return "@$targetPackageName/$relPath"
         }
       }
     }
 
-    // Default: plain relative path from the source file's directory.
-    val sourceDir = sourceFile.parent ?: return null
-    return VfsUtilCore.findRelativePath(sourceDir, targetFile, '/')
+    // Fall back to a relative path only when there is no PKL project context on either side.
+    if (targetPklProjectDir == null || sourcePklProjectDir == null) {
+      val sourceDir = sourceFile.parent ?: return null
+      return VfsUtilCore.findRelativePath(sourceDir, targetFile, '/')
+    }
+
+    // Both sides have a PKL project but we could not determine a dep name (e.g. target project
+    // has no packageUri). Return null so the import is left unchanged rather than producing a
+    // fragile relative path.
+    return null
+  }
+
+  /**
+   * Adds `["depName"] = import("relPath/PklProject")` to the `dependencies` block of the
+   * `PklProject` file in [sourcePklProjectDir]. Creates the `dependencies` block if absent.
+   * Does nothing if the entry is already present.
+   */
+  private fun addDependencyToPklProject(
+    sourcePklProjectDir: VirtualFile,
+    targetPklProjectDir: VirtualFile,
+    depName: String,
+    ideaProject: Project
+  ) {
+    val pklProjectVFile = sourcePklProjectDir.findChild(PKL_PROJECT_FILENAME) ?: return
+
+    // Relative path from the source project's directory to the target PklProject file.
+    val relToTarget =
+      VfsUtilCore.findRelativePath(sourcePklProjectDir, targetPklProjectDir, '/') ?: return
+    val importPath = "$relToTarget/$PKL_PROJECT_FILENAME"
+
+    val pklModule =
+      PsiManager.getInstance(ideaProject).findFile(pklProjectVFile) as? PklModule ?: return
+    val depsProperty = pklModule.properties.find { it.name == "dependencies" }
+
+    // Skip if this dep name is already present (avoids duplicate entries).
+    if (depsProperty?.text?.contains("[\"$depName\"]") == true) return
+
+    val document = FileDocumentManager.getInstance().getDocument(pklProjectVFile) ?: return
+    val newEntry = "  [\"$depName\"] = import(\"$importPath\")\n"
+
+    if (depsProperty != null) {
+      // Insert before the closing `}` of the existing dependencies block.
+      val objectBody = depsProperty.objectBodyList.firstOrNull() ?: return
+      document.insertString(objectBody.textRange.endOffset - 1, newEntry)
+    } else {
+      // Append a brand-new dependencies block at the end of the file.
+      document.insertString(document.textLength, "\ndependencies {\n$newEntry}\n")
+    }
   }
 
   companion object {

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.psi
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
@@ -273,9 +274,27 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       // Append a brand-new dependencies block at the end of the file.
       document.insertString(document.textLength, "\ndependencies {\n$newEntry}\n")
     }
+
+    // Schedule a PKL project sync (pkl project resolve → PklProject.deps.json) to run after
+    // the current write action completes. A project-level flag prevents multiple syncs when
+    // several references are updated in a single refactoring pass.
+    if (ideaProject.getUserData(SYNC_SCHEDULED_KEY) != true) {
+      ideaProject.putUserData(SYNC_SCHEDULED_KEY, true)
+      ApplicationManager.getApplication().invokeLater {
+        ideaProject.putUserData(SYNC_SCHEDULED_KEY, null)
+        FileDocumentManager.getInstance().saveAllDocuments()
+        ideaProject.pklProjectService.syncProjects()
+      }
+    }
   }
 
   companion object {
+    /**
+     * Project-level flag used to ensure at most one PKL project sync is scheduled per
+     * refactoring operation (even when multiple references are updated in one pass).
+     */
+    private val SYNC_SCHEDULED_KEY = Key.create<Boolean>("pkl.depSync.scheduled")
+
     /**
      * Walks up the directory tree from [file] and returns the first ancestor directory that
      * contains a `PklProject` file, or `null` if none is found.

--- a/src/main/kotlin/org/pkl/intellij/psi/PklSimpleTypeNameReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklSimpleTypeNameReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
-import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.parentOfType
+import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.resolve.ResolveVisitors
 import org.pkl.intellij.resolve.Resolvers

--- a/src/main/kotlin/org/pkl/intellij/psi/PklSimpleTypeNameReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklSimpleTypeNameReference.kt
@@ -17,6 +17,7 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
+import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.parentOfType
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.resolve.ResolveVisitors
@@ -54,4 +55,7 @@ class PklSimpleTypeNameReference(private val simpleTypeName: PklSimpleTypeName) 
   override fun resolve(): PklElement? {
     return resolveContextual(simpleTypeName.enclosingModule?.pklProject)
   }
+
+  @Throws(IncorrectOperationException::class)
+  override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklSimpleTypeNameReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklSimpleTypeNameReference.kt
@@ -56,6 +56,5 @@ class PklSimpleTypeNameReference(private val simpleTypeName: PklSimpleTypeName) 
     return resolveContextual(simpleTypeName.enclosingModule?.pklProject)
   }
 
-  @Throws(IncorrectOperationException::class)
   override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklSuperAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklSuperAccessReference.kt
@@ -44,6 +44,5 @@ class PklSuperAccessReference(private val accessName: PklSuperAccessName) :
 
   override fun resolve(): PsiElement? = resolveContextual(accessName.enclosingModule?.pklProject)
 
-  @Throws(IncorrectOperationException::class)
   override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklSuperAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklSuperAccessReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
-import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.parentOfType
+import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.resolve.ResolveVisitors
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklSuperAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklSuperAccessReference.kt
@@ -17,6 +17,7 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
+import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.parentOfType
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.resolve.ResolveVisitors
@@ -42,4 +43,7 @@ class PklSuperAccessReference(private val accessName: PklSuperAccessName) :
   }
 
   override fun resolve(): PsiElement? = resolveContextual(accessName.enclosingModule?.pklProject)
+
+  @Throws(IncorrectOperationException::class)
+  override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklUnqualifiedAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklUnqualifiedAccessReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
-import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.parentOfType
+import com.intellij.util.IncorrectOperationException
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.resolve.ResolveVisitors
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklUnqualifiedAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklUnqualifiedAccessReference.kt
@@ -17,6 +17,7 @@ package org.pkl.intellij.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
+import com.intellij.util.IncorrectOperationException
 import com.intellij.psi.util.parentOfType
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.resolve.ResolveVisitors
@@ -44,4 +45,7 @@ class PklUnqualifiedAccessReference(private val accessName: PklUnqualifiedAccess
   override fun resolve(): PsiElement? {
     return resolveContextual(accessName.enclosingModule?.pklProject)
   }
+
+  @Throws(IncorrectOperationException::class)
+  override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklUnqualifiedAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklUnqualifiedAccessReference.kt
@@ -46,6 +46,5 @@ class PklUnqualifiedAccessReference(private val accessName: PklUnqualifiedAccess
     return resolveContextual(accessName.enclosingModule?.pklProject)
   }
 
-  @Throws(IncorrectOperationException::class)
   override fun bindToElement(newTarget: PsiElement): PsiElement = element
 }


### PR DESCRIPTION
## What

Fix a series of crashes and missing behaviors triggered when moving
`.pkl` files via IntelliJ's refactoring engine (drag-and-drop or
Refactor > Move).

## Why

The default `PsiReferenceBase.bindToElement` unconditionally throws
`IncorrectOperationException`. Because every Pkl reference class
(`PklModuleUriReference`, `PklUnqualifiedAccessReference`,
`PklSuperAccessReference`, `PklModuleNameReference`,
`PklSimpleTypeNameReference`, `PklModuleReference`) inherits this
default, any file move that touched a Pkl source file would crash the
refactoring processor.

Beyond stopping the crash, moves across PKL project boundaries need
special URI handling: a plain relative path would be wrong once the
file lands in a different project, so the URI must use the
`@<depName>/<path>` project-dependency format instead.

## Changes

**Stop the crash**

- Override `bindToElement` on all six `PsiReferenceBase` subclasses.
- Five of them (non-URI references) use a no-op that returns `element`
  unchanged — these references are unaffected by file location.
- `PklModuleUriReference` gets a full implementation (see below).

**Smart URI rewriting in `PklModuleUriReference.bindToElement`**

- `file:` URIs → replaced with the new absolute VFS URL.
- Relative URIs, same PKL project → recomputed as a plain relative
  path from the new source location.
- Relative URIs, crossing PKL project boundaries →
  1. If the source project already declares the target project as a
     dependency, rewrite as `@<depName>/<path-from-dep-root>`.
  2. Otherwise derive the dep name from the target project's
     `packageUri` (e.g. `package://localhost:0/tests@1.0.0` →
     `"tests"`), insert a new `["tests"] = import("…/PklProject")`
     entry into the source `PklProject` file, and rewrite as
     `@tests/<path>`.
  3. If neither project has a `PklProject` ancestor, fall back to a
     plain relative path.
  4. URIs with a non-file scheme (`pkl:`, `package:`, `https:`,
     `modulepath:`) are left unchanged.
- After inserting a new dependency entry, schedule
  `pklProjectService.syncProjects()` via `invokeLater` so
  `PklProject.deps.json` is regenerated without requiring a manual
  Sync click.  A project-level flag deduplicates multiple syncs when
  several references are updated in one refactoring pass.

**Refresh highlights after sync**

- Add `DaemonCodeAnalyzer.restart()` (via `invokeLater`) at the end of
  `PklProjectService.syncProjects()`.  Without this, `@dep/path`
  imports kept showing "unresolved" warnings in open editors even after
  the sync had fully populated the new dependency, because incrementing
  a custom `ModificationTracker` does not automatically re-trigger
  IntelliJ's daemon code analyzer.

## Checklist

- [x] Follows conventions of surrounding code
- [x] Build passes (`./gradlew build`)
- [x] Spotless formatting applied