### PR TITLE
Support nested path creation when creating new Pkl files

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/action/PklCreateFileAction.kt
+++ b/src/main/kotlin/org/pkl/intellij/action/PklCreateFileAction.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/pkl/intellij/action/PklCreateFileAction.kt
+++ b/src/main/kotlin/org/pkl/intellij/action/PklCreateFileAction.kt
@@ -56,15 +56,21 @@ class PklCreateFileAction :
   ): PsiFile? =
     try {
       val project = dir.project
+      val parts = name.split("/")
+      val fileName = parts.last()
+      val targetDir =
+        parts.dropLast(1).fold(dir) { current, segment ->
+          current.findSubdirectory(segment) ?: current.createSubdirectory(segment)
+        }
       val templateManager = FileTemplateManager.getInstance(project)
       val properties = templateManager.defaultProperties
       properties["PKL_VERSION"] = project.pklBaseModule.pklVersion.toString()
       val dialog =
         CreateFromTemplateDialog(
           project,
-          dir,
+          targetDir,
           template,
-          AttributesDefaults(name).withFixedName(true),
+          AttributesDefaults(fileName).withFixedName(true),
           properties
         )
       dialog.create().containingFile

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -228,6 +228,8 @@
     <localInspection shortName="pkl.UnusedLocalDefinitions" displayName="Unused local definitions"
                      groupName="Pkl" enabledByDefault="true" level="WARNING" language="Pkl"
                      implementationClass="org.pkl.intellij.PklUnusedLocalDefinitionsInspection"/>
+    <internalFileTemplate name="Pkl File"/>
+    <internalFileTemplate name="Pkl Template"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
## What

When creating a new Pkl file, the user can now enter a path with
intermediate directories (e.g. `tests/general_test.pkl`). Missing
directories are created automatically starting from the directory where
the action was invoked.

Also registers the `Pkl File` and `Pkl Template` file templates as
`<internalFileTemplate>` entries in `plugin.xml`, which prevents an
assertion error from `FileTypeUsageCounterCollector` that was triggered
after the file was successfully created.

## Why

Previously, entering a slash-separated path caused an
`IncorrectOperationException` because the VFS does not allow slashes in
file names. The fix splits the name on `/`, walks (or creates) each
intermediate directory, and passes only the leaf filename to
`CreateFromTemplateDialog`.

The missing `internalFileTemplate` registrations caused a secondary
assertion failure even though the file was created correctly — IntelliJ
requires bundled templates to be declared in `plugin.xml` for usage
statistics collection.

## Checklist

* Conventions of surrounding code are followed.
* Changes are limited to the minimal set needed to fix the reported behavior.

By submitting this pull request, I acknowledge that I have the right to
license my contribution to Apple and the community, and agree that my
contribution is licensed under the Apache 2.0 license.