### PR TITLE
Add object members to structure view

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ grammarKit = "2023.3"
 grammarKitPlugin = "2022.3.2.2"
 # IntelliJ version to build and verify against. Use latest patch version of `intellijSinceBuild`.
 # https://www.jetbrains.com/idea/download/other.html
-intellij = "2024.3"
+intellij = "2024.3.3"
 # IntelliJ version to run against (`runIde` task). Use latest version.
 # https://www.jetbrains.com/idea/download/#section=mac
 intellijRunIde = "2024.3"

--- a/src/main/grammar/pkl.bnf
+++ b/src/main/grammar/pkl.bnf
@@ -650,6 +650,7 @@ objectBody ::= '{' objectBodyParameterList? objectMember* '}' {
 
 objectMember ::= objectProperty | objectMethod | objectEntry | memberPredicate | forGenerator | whenGenerator | objectElement | objectSpread {
   recoverWhile = recoverObjectMember
+  implements = "org.pkl.intellij.psi.PklNavigableElement"
   mixin = "org.pkl.intellij.psi.PklObjectMemberBase"
 }
 
@@ -699,6 +700,7 @@ objectEntry ::= SEP? '[' expr ']' (objectMemberAssign | objectBody+) {
     keyExpr = "/expr[0]"
     valueExpr = "/expr[1]"
   ]
+  mixin = "org.pkl.intellij.psi.PklObjectEntryBase"
 }
 
 private objectMemberAssign ::= '=' expr { pin = 1 }
@@ -710,6 +712,7 @@ memberPredicate ::= SEP? '[[' expr ']]' (objectMemberAssign | objectBody+) {
     "org.pkl.intellij.psi.PklObjectBodyListOwner"
     "org.pkl.intellij.psi.PklSuppressWarningsTarget"
   ]
+  mixin = "org.pkl.intellij.psi.PklMemberPredicateBase"
   methods = [
     conditionExpr = "/expr[0]"
     valueExpr = "/expr[1]"
@@ -720,6 +723,7 @@ forGenerator ::= for '(' typedIdentifier (',' typedIdentifier)? in expr ')' obje
   pin = 1
   extends = objectMember
   implements = "org.pkl.intellij.psi.PklSuppressWarningsTarget"
+  mixin = "org.pkl.intellij.psi.PklForGeneratorBase"
   methods = [
     keyValueVars = "typedIdentifier"
     iterableExpr = "expr"
@@ -729,6 +733,7 @@ forGenerator ::= for '(' typedIdentifier (',' typedIdentifier)? in expr ')' obje
 whenGenerator ::= when '(' expr ')' (objectBody ('else' objectBody)?) {
   pin = 1
   extends = objectMember
+  mixin = "org.pkl.intellij.psi.PklWhenGeneratorBase"
   methods = [
     conditionExpr = "expr"
     thenBody = "/objectBody[0]"
@@ -738,11 +743,13 @@ whenGenerator ::= when '(' expr ')' (objectBody ('else' objectBody)?) {
 
 objectSpread ::= ('...' | '...?') expr {
   extends = objectMember
+  mixin = "org.pkl.intellij.psi.PklObjectSpreadBase"
 }
 
 objectElement ::= expr {
   extends = objectMember
   implements = "org.pkl.intellij.psi.PklSuppressWarningsTarget"
+  mixin = "org.pkl.intellij.psi.PklObjectElementBase"
 }
 
 stringConstant ::= STRING_START stringConstantContent STRING_END {

--- a/src/main/kotlin/org/pkl/intellij/PklBreadcrumbsProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/PklBreadcrumbsProvider.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import com.intellij.lang.Language
 import com.intellij.psi.PsiElement
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
 import org.pkl.intellij.psi.*
+import org.pkl.intellij.util.toDisplayText
 
 class PklBreadcrumbsProvider : BreadcrumbsProvider {
   override fun getLanguages(): Array<Language> = arrayOf(PklLanguage)
@@ -45,102 +46,22 @@ class PklBreadcrumbsProvider : BreadcrumbsProvider {
     }
   }
 
-  private fun PklArgumentList?.renderMethodCallArguments(): String {
-    if (this == null) return ""
-    return elements.joinToString(", ", prefix = "(", postfix = ")") { it.toDisplayText() ?: "…" }
-  }
-
-  private fun PklExpr.toDisplayText(): String? {
-    return when (this) {
-      is PklStringLiteral -> this.content.escapedText()
-      is PklNumberLiteral,
-      is PklTrueLiteral,
-      is PklFalseLiteral,
-      is PklNullLiteral,
-      is PklThisExpr,
-      is PklModuleExpr,
-      is PklOuterExpr -> this.text
-      is PklTypeTestExpr -> (this.expr.toDisplayText() ?: "…") + " is " + this.type.text
-      is PklTypeCastExpr -> (this.expr.toDisplayText() ?: "…") + " as " + this.type.text
-      is PklLogicalNotExpr -> this.expr?.toDisplayText()?.let { "!$it" }
-      is PklUnaryMinusExpr -> this.expr?.toDisplayText()?.let { "-$it" }
-      is PklNonNullAssertionExpr -> this.expr.toDisplayText()?.let { "$it!!" }
-      is PklNewExpr -> "new " + (this.type?.text?.let { "$it " } ?: "") + "{…}"
-      is PklSubscriptBinExpr -> {
-        val leftExpr = this.leftExpr.toDisplayText() ?: return null
-        val rightExpr = this.rightExpr?.toDisplayText() ?: "…"
-        return "$leftExpr[$rightExpr]"
-      }
-      is PklSuperAccessExpr -> "super.${memberNameText}${argumentList.renderMethodCallArguments()}"
-      is PklSuperSubscriptExpr -> "super[${expr.toDisplayText() ?: "…"}]"
-      is PklBinExpr -> {
-        val leftExpr = this.leftExpr.toDisplayText() ?: "…"
-        val rightExpr = this.rightExpr?.toDisplayText() ?: "…"
-        return "$leftExpr ${operator.text} $rightExpr"
-      }
-      is PklUnqualifiedAccessExpr -> "$memberNameText${argumentList.renderMethodCallArguments()}"
-      is PklQualifiedAccessExpr -> {
-        val receiver = (this.receiverExpr.toDisplayText() ?: "<receiver>")
-        receiver + "." + this.memberNameText + argumentList.renderMethodCallArguments()
-      }
-      is PklParenthesizedExpr -> expr?.toDisplayText()?.let { "($it)" }
-      else -> null
-    }
-  }
-
   private val classHandler = handler<PklClass> { it.identifier?.text ?: "<class>" }
 
   private val typealiasHandler = handler<PklTypeAlias> { it.identifier?.text ?: "<typealias>" }
 
-  private val propertyHandler = handler<PklProperty> { it.propertyName.identifier.text }
+  private val propertyHandler = handler<PklClassProperty> { it.propertyName.identifier.text }
 
-  private val objectEntryHandler =
-    handler<PklObjectEntry> { it.keyExpr?.toDisplayText() ?: "<entry>" }
-
-  private val memberPredicateHandler =
-    handler<PklMemberPredicate> { elem ->
-      buildString {
-        append("[[")
-        append(elem.conditionExpr?.toDisplayText() ?: "…")
-        append("]] {…}")
-      }
-    }
-
-  private val forGeneratorHandler =
-    handler<PklForGenerator> { elem ->
-      buildString {
-        append("for (")
-        append(elem.keyValueVars[0].identifier.text)
-        if (elem.keyValueVars.size == 2) {
-          append(", ")
-          append(elem.keyValueVars[1].identifier.text)
-        }
-        append(" in ")
-        append(elem.iterableExpr?.toDisplayText() ?: "…")
-        append(") {…}")
-      }
-    }
-
-  private val whenGeneratorHandler =
-    handler<PklWhenGenerator> { elem ->
-      buildString {
-        append("when (")
-        append(elem.conditionExpr?.toDisplayText() ?: "…")
-        append(") {…}")
-      }
-    }
+  private val objectMemberHandler = handler<PklObjectMember> { it.presentation!!.presentableText!! }
 
   private val annotationHandler =
     handler<PklAnnotation> { elem -> elem.typeName?.text?.let { "@$it" } ?: "<annotation>" }
 
-  private val methodHandler = handler<PklMethod> { it.identifier?.text ?: "<method>" }
+  private val methodHandler = handler<PklMethod> { it.presentation.presentableText!! }
 
   private val newExprHandler = handler<PklNewExpr> { it.toDisplayText()!! }
 
-  private val amendExprHandler =
-    handler<PklAmendExpr> { elem ->
-      elem.parentExpr.toDisplayText()?.let { "$it {…}" } ?: "(<parent>) {…}"
-    }
+  private val amendExprHandler = handler<PklAmendExpr> { it.toDisplayText()!! }
 
   private fun PsiElement.isThenBody(): Boolean {
     val p = parent
@@ -196,10 +117,7 @@ class PklBreadcrumbsProvider : BreadcrumbsProvider {
       classHandler,
       typealiasHandler,
       propertyHandler,
-      objectEntryHandler,
-      memberPredicateHandler,
-      forGeneratorHandler,
-      whenGeneratorHandler,
+      objectMemberHandler,
       annotationHandler,
       methodHandler,
       newExprHandler,

--- a/src/main/kotlin/org/pkl/intellij/PklStructureView.kt
+++ b/src/main/kotlin/org/pkl/intellij/PklStructureView.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import com.intellij.ide.structureView.StructureViewModel.ElementInfoProvider
 import com.intellij.lang.PsiStructureViewFactory
 import com.intellij.navigation.ItemPresentation
 import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 import org.pkl.intellij.psi.*
 import org.pkl.intellij.util.toTypedArray
 
@@ -41,13 +43,22 @@ class PklStructureViewFactory : PsiStructureViewFactory {
               PklClass::class.java,
               PklTypeAlias::class.java,
               PklClassMethod::class.java,
-              PklClassProperty::class.java
+              PklClassProperty::class.java,
+              PklObjectProperty::class.java,
+              PklObjectMethod::class.java,
+              PklObjectEntry::class.java,
+              PklForGenerator::class.java,
+              PklWhenGenerator::class.java,
+              PklMemberPredicate::class.java,
             )
 
           override fun isAlwaysShowsPlus(element: StructureViewTreeElement): Boolean = false
 
           override fun isAlwaysLeaf(element: StructureViewTreeElement): Boolean =
-            element.value !is PklModule && element.value !is PklClass
+            element.value !is PklModule &&
+              element.value !is PklClass &&
+              element.value !is PklObjectBodyListOwner &&
+              element.value !is PklObjectMember
         }
       }
     }
@@ -62,13 +73,12 @@ class PklStructureViewTreeElement(private val psi: PklNavigableElement) : Struct
       override fun getLocationString(): String? = null // doesn't make sense for structure view
     }
 
-  @Suppress("RemoveExplicitTypeArguments") // kotlinc complains otherwise
   override fun getChildren(): Array<StructureViewTreeElement> {
     return when (psi) {
       is PklModule -> psi.members.map { PklStructureViewTreeElement(it) }.toTypedArray()
       is PklClass ->
         psi.members.map { PklStructureViewTreeElement(it) }.toTypedArray<StructureViewTreeElement>()
-      else -> StructureViewTreeElement.EMPTY_ARRAY
+      else -> psi.directObjectMembers().map { PklStructureViewTreeElement(it) }.toTypedArray()
     }
   }
 
@@ -77,4 +87,30 @@ class PklStructureViewTreeElement(private val psi: PklNavigableElement) : Struct
   override fun getValue(): Any = psi
 
   override fun canNavigateToSource(): Boolean = psi.canNavigateToSource()
+}
+
+/**
+ * Recursively collects the direct [PklObjectMember] children of a PSI node by traversing into any
+ * [PklObjectBody] found in the subtree, but not crossing [PklObjectMember] boundaries (those become
+ * their own structure view nodes and will recurse independently).
+ *
+ * This handles object members inside expressions such as `new { }` and amend expressions, not only
+ * the `objectBodyList` of [PklObjectBodyListOwner].
+ */
+private fun PsiElement.directObjectMembers(): Sequence<PklObjectMember> = sequence {
+  for (child in children) {
+    when (child) {
+      is PklObjectBody ->
+        yieldAll(
+          child.members.filter { member ->
+            // Exclude bare object elements (literals, variable refs, etc.) that contain no
+            // nested object body — they have no structural children worth showing.
+            member !is PklObjectElement ||
+              PsiTreeUtil.findChildOfType(member, PklObjectBody::class.java) != null
+          }
+        )
+      is PklObjectMember -> {} // its own structure view node — don't descend
+      else -> yieldAll(child.directObjectMembers())
+    }
+  }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklAstWrapperPsiElement.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklAstWrapperPsiElement.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/pkl/intellij/psi/PklForGeneratorBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklForGeneratorBase.kt
@@ -1,0 +1,42 @@
+/**
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.psi
+
+import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
+import javax.swing.Icon
+import org.pkl.intellij.util.toDisplayText
+
+abstract class PklForGeneratorBase(node: ASTNode) : PklObjectMemberBase(node), PklForGenerator {
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
+
+      override fun getIcon(unused: Boolean): Icon? = null
+
+      override fun getPresentableText(): String = buildString {
+        append("for (")
+        append(keyValueVars[0].identifier.text)
+        if (keyValueVars.size == 2) {
+          append(", ")
+          append(keyValueVars[1].identifier.text)
+        }
+        append(" in ")
+        append(iterableExpr?.toDisplayText() ?: "…")
+        append(") {…}")
+      }
+    }
+}

--- a/src/main/kotlin/org/pkl/intellij/psi/PklMemberPredicateBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklMemberPredicateBase.kt
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.psi
+
+import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
+import javax.swing.Icon
+import org.pkl.intellij.util.toDisplayText
+
+abstract class PklMemberPredicateBase(node: ASTNode) :
+  PklObjectMemberBase(node), PklMemberPredicate {
+  override fun getIcon(flags: Int): Icon? = null
+
+  override fun getPresentation(): ItemPresentation {
+    return object : ItemPresentation {
+      override fun getPresentableText(): String = buildString {
+        append("[[")
+        append(conditionExpr?.toDisplayText() ?: "…")
+        append("]] {…}")
+      }
+
+      override fun getIcon(flags: Boolean): Icon? = null
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/intellij/psi/PklMethod.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklMethod.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.psi
 
+import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
 
 interface PklMethod : PklModifierListOwner, PklNavigableElement, PklSuppressWarningsTarget {
@@ -35,4 +36,6 @@ interface PklMethod : PklModifierListOwner, PklNavigableElement, PklSuppressWarn
   val body: PklExpr?
 
   val hasParameters: Boolean
+
+  override fun getPresentation(): ItemPresentation
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectElementBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectElementBase.kt
@@ -15,24 +15,20 @@
  */
 package org.pkl.intellij.psi
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElementVisitor
+import com.intellij.navigation.ItemPresentation
+import javax.swing.Icon
+import org.pkl.intellij.util.toDisplayText
 
-abstract class PklAstWrapperPsiElement(node: ASTNode) : ASTWrapperPsiElement(node) {
-  // improve readability in PSI viewer
-  override fun toString(): String {
-    return javaClass.name.removePrefix("org.pkl.intellij.psi.impl.Pkl").removeSuffix("Impl")
-  }
+abstract class PklObjectElementBase(node: ASTNode) : PklObjectMemberBase(node), PklObjectElement {
+  override fun getIcon(flags: Int): Icon? = null
 
-  override fun acceptChildren(visitor: PsiElementVisitor) {
-    var child = firstChild
-    while (child != null) {
-      // get next sibling before calling `accept()` so that visitor can `replace()` child without
-      // affecting traversal
-      val nextSibling = child.nextSibling
-      child.accept(visitor)
-      child = nextSibling
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
+
+      override fun getIcon(unused: Boolean): Icon? = null
+
+      override fun getPresentableText(): String? = expr.toDisplayText()
     }
-  }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectEntryBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectEntryBase.kt
@@ -15,24 +15,23 @@
  */
 package org.pkl.intellij.psi
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.icons.AllIcons
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElementVisitor
+import com.intellij.navigation.ItemPresentation
+import javax.swing.Icon
+import org.pkl.intellij.util.toDisplayText
 
-abstract class PklAstWrapperPsiElement(node: ASTNode) : ASTWrapperPsiElement(node) {
-  // improve readability in PSI viewer
-  override fun toString(): String {
-    return javaClass.name.removePrefix("org.pkl.intellij.psi.impl.Pkl").removeSuffix("Impl")
-  }
+abstract class PklObjectEntryBase(node: ASTNode) : PklObjectMemberBase(node), PklObjectEntry {
+  override fun getIcon(flags: Int): Icon = AllIcons.Json.Array
 
-  override fun acceptChildren(visitor: PsiElementVisitor) {
-    var child = firstChild
-    while (child != null) {
-      // get next sibling before calling `accept()` so that visitor can `replace()` child without
-      // affecting traversal
-      val nextSibling = child.nextSibling
-      child.accept(visitor)
-      child = nextSibling
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
+
+      override fun getIcon(unused: Boolean): Icon = AllIcons.Json.Array
+
+      override fun getPresentableText(): String = buildString {
+        append(keyExpr?.toDisplayText() ?: "<entry>")
+      }
     }
-  }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectMemberBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectMemberBase.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,23 @@
 package org.pkl.intellij.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import org.pkl.intellij.packages.dto.PklProject
+import org.pkl.intellij.type.Type
+import org.pkl.intellij.type.TypeParameterBindings
 
 abstract class PklObjectMemberBase(node: ASTNode) : PklAstWrapperPsiElement(node), PklObjectMember {
+  override fun getName(): String? = null
+
+  override fun getNameIdentifier(): PsiElement? = null
+
+  override fun getLookupElementType(
+    base: PklBaseModule,
+    bindings: TypeParameterBindings,
+    context: PklProject?
+  ): Type {
+    throw AssertionError("This method should have been overridden by ${this::class.qualifiedName}.")
+  }
+
   override fun toString(): String = super.toString() + "($name)"
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectMethodBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectMethodBase.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.pkl.intellij.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
 import javax.swing.Icon
 import org.pkl.intellij.PklIcons
@@ -49,4 +50,13 @@ abstract class PklObjectMethodBase(node: ASTNode) : PklAstWrapperPsiElement(node
     get() = !parameterList?.elements.isNullOrEmpty()
 
   override fun toString(): String = "ObjectMethod($name)"
+
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
+
+      override fun getIcon(unused: Boolean): Icon = getIcon(0)
+
+      override fun getPresentableText(): String = name ?: "<method>"
+    }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectPropertyBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectPropertyBase.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.pkl.intellij.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
 import javax.swing.Icon
 import org.pkl.intellij.PklIcons
@@ -46,4 +47,16 @@ abstract class PklObjectPropertyBase(node: ASTNode) :
   override fun isDefinition(context: PklProject?): Boolean = type != null || isLocal
 
   override fun toString(): String = "ObjectProperty($name)"
+
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
+
+      override fun getIcon(unused: Boolean): Icon = getIcon(0)
+
+      override fun getPresentableText(): String = buildString {
+        append(name)
+        type?.let { append(": ").append(it.text) }
+      }
+    }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectSpreadBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectSpreadBase.kt
@@ -18,17 +18,16 @@ package org.pkl.intellij.psi
 import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
 import javax.swing.Icon
-import org.pkl.intellij.PklIcons
 import org.pkl.intellij.util.toDisplayText
 
 abstract class PklObjectSpreadBase(node: ASTNode) : PklObjectMemberBase(node), PklObjectSpread {
-  override fun getIcon(flags: Int): Icon = PklIcons.PROPERTY
+  override fun getIcon(flags: Int): Icon? = null
 
   override fun getPresentation(): ItemPresentation =
     object : ItemPresentation {
       override fun getLocationString(): String? = null
 
-      override fun getIcon(unused: Boolean): Icon = PklIcons.PROPERTY
+      override fun getIcon(unused: Boolean): Icon? = null
 
       override fun getPresentableText(): String = buildString {
         append("...")

--- a/src/main/kotlin/org/pkl/intellij/psi/PklObjectSpreadBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklObjectSpreadBase.kt
@@ -15,24 +15,25 @@
  */
 package org.pkl.intellij.psi
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElementVisitor
+import com.intellij.navigation.ItemPresentation
+import javax.swing.Icon
+import org.pkl.intellij.PklIcons
+import org.pkl.intellij.util.toDisplayText
 
-abstract class PklAstWrapperPsiElement(node: ASTNode) : ASTWrapperPsiElement(node) {
-  // improve readability in PSI viewer
-  override fun toString(): String {
-    return javaClass.name.removePrefix("org.pkl.intellij.psi.impl.Pkl").removeSuffix("Impl")
-  }
+abstract class PklObjectSpreadBase(node: ASTNode) : PklObjectMemberBase(node), PklObjectSpread {
+  override fun getIcon(flags: Int): Icon = PklIcons.PROPERTY
 
-  override fun acceptChildren(visitor: PsiElementVisitor) {
-    var child = firstChild
-    while (child != null) {
-      // get next sibling before calling `accept()` so that visitor can `replace()` child without
-      // affecting traversal
-      val nextSibling = child.nextSibling
-      child.accept(visitor)
-      child = nextSibling
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
+
+      override fun getIcon(unused: Boolean): Icon = PklIcons.PROPERTY
+
+      override fun getPresentableText(): String = buildString {
+        append("...")
+        if (isNullable) append("?")
+        append(expr.toDisplayText() ?: "<expr>")
+      }
     }
-  }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklWhenGeneratorBase.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklWhenGeneratorBase.kt
@@ -15,24 +15,22 @@
  */
 package org.pkl.intellij.psi
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElementVisitor
+import com.intellij.navigation.ItemPresentation
+import javax.swing.Icon
+import org.pkl.intellij.util.toDisplayText
 
-abstract class PklAstWrapperPsiElement(node: ASTNode) : ASTWrapperPsiElement(node) {
-  // improve readability in PSI viewer
-  override fun toString(): String {
-    return javaClass.name.removePrefix("org.pkl.intellij.psi.impl.Pkl").removeSuffix("Impl")
-  }
+abstract class PklWhenGeneratorBase(node: ASTNode) : PklObjectMemberBase(node), PklWhenGenerator {
+  override fun getPresentation(): ItemPresentation =
+    object : ItemPresentation {
+      override fun getLocationString(): String? = null
 
-  override fun acceptChildren(visitor: PsiElementVisitor) {
-    var child = firstChild
-    while (child != null) {
-      // get next sibling before calling `accept()` so that visitor can `replace()` child without
-      // affecting traversal
-      val nextSibling = child.nextSibling
-      child.accept(visitor)
-      child = nextSibling
+      override fun getIcon(unused: Boolean): Icon? = null
+
+      override fun getPresentableText(): String = buildString {
+        append("when (")
+        append(conditionExpr?.toDisplayText() ?: "…")
+        append(") {…}")
+      }
     }
-  }
 }

--- a/src/main/kotlin/org/pkl/intellij/util/Util.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/Util.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,32 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
 import java.util.regex.Pattern
 import kotlin.math.max
+import org.pkl.intellij.psi.PklAmendExpr
+import org.pkl.intellij.psi.PklArgumentList
+import org.pkl.intellij.psi.PklBinExpr
+import org.pkl.intellij.psi.PklExpr
+import org.pkl.intellij.psi.PklFalseLiteral
+import org.pkl.intellij.psi.PklLogicalNotExpr
 import org.pkl.intellij.psi.PklModule
+import org.pkl.intellij.psi.PklModuleExpr
+import org.pkl.intellij.psi.PklNewExpr
+import org.pkl.intellij.psi.PklNonNullAssertionExpr
+import org.pkl.intellij.psi.PklNullLiteral
+import org.pkl.intellij.psi.PklNumberLiteral
+import org.pkl.intellij.psi.PklOuterExpr
+import org.pkl.intellij.psi.PklParenthesizedExpr
+import org.pkl.intellij.psi.PklQualifiedAccessExpr
+import org.pkl.intellij.psi.PklStringLiteral
+import org.pkl.intellij.psi.PklSubscriptBinExpr
+import org.pkl.intellij.psi.PklSuperAccessExpr
+import org.pkl.intellij.psi.PklSuperSubscriptExpr
+import org.pkl.intellij.psi.PklThisExpr
+import org.pkl.intellij.psi.PklTrueLiteral
+import org.pkl.intellij.psi.PklTypeCastExpr
+import org.pkl.intellij.psi.PklTypeTestExpr
+import org.pkl.intellij.psi.PklUnaryMinusExpr
+import org.pkl.intellij.psi.PklUnqualifiedAccessExpr
+import org.pkl.intellij.psi.escapedText
 
 private const val SIGNIFICAND_MASK = 0x000fffffffffffffL
 
@@ -380,4 +405,48 @@ fun InputStream.copyToWithIndicator(
     bytesCopied += bytes
     bytes = read(buffer)
   }
+}
+
+fun PklExpr.toDisplayText(): String? {
+  return when (this) {
+    is PklStringLiteral -> this.content.escapedText()
+    is PklNumberLiteral,
+    is PklTrueLiteral,
+    is PklFalseLiteral,
+    is PklNullLiteral,
+    is PklThisExpr,
+    is PklModuleExpr,
+    is PklOuterExpr -> this.text
+    is PklTypeTestExpr -> (this.expr.toDisplayText() ?: "…") + " is " + this.type.text
+    is PklTypeCastExpr -> (this.expr.toDisplayText() ?: "…") + " as " + this.type.text
+    is PklLogicalNotExpr -> this.expr?.toDisplayText()?.let { "!$it" }
+    is PklUnaryMinusExpr -> this.expr?.toDisplayText()?.let { "-$it" }
+    is PklNonNullAssertionExpr -> this.expr.toDisplayText()?.let { "$it!!" }
+    is PklNewExpr -> "new " + (this.type?.text?.let { "$it " } ?: "") + "{…}"
+    is PklSubscriptBinExpr -> {
+      val leftExpr = this.leftExpr.toDisplayText() ?: return null
+      val rightExpr = this.rightExpr?.toDisplayText() ?: "…"
+      "$leftExpr[$rightExpr]"
+    }
+    is PklSuperAccessExpr -> "super.${memberNameText}${argumentList.renderMethodCallArguments()}"
+    is PklSuperSubscriptExpr -> "super[${expr.toDisplayText() ?: "…"}]"
+    is PklBinExpr -> {
+      val leftExpr = this.leftExpr.toDisplayText() ?: "…"
+      val rightExpr = this.rightExpr?.toDisplayText() ?: "…"
+      "$leftExpr ${operator.text} $rightExpr"
+    }
+    is PklUnqualifiedAccessExpr -> "$memberNameText${argumentList.renderMethodCallArguments()}"
+    is PklQualifiedAccessExpr -> {
+      val receiver = (this.receiverExpr.toDisplayText() ?: "<receiver>")
+      receiver + "." + this.memberNameText + argumentList.renderMethodCallArguments()
+    }
+    is PklParenthesizedExpr -> expr?.toDisplayText()?.let { "($it)" }
+    is PklAmendExpr -> parentExpr.toDisplayText()?.let { "$it {…}" } ?: "(<parent>) {…}"
+    else -> null
+  }
+}
+
+private fun PklArgumentList?.renderMethodCallArguments(): String {
+  if (this == null) return ""
+  return elements.joinToString(", ", prefix = "(", postfix = ")") { it.toDisplayText() ?: "…" }
 }


### PR DESCRIPTION
This adds regular object members to the structure view tool window.

* Create item presentations for all object members
* Make both `PklStructureView` and  `PklBreadcrumbsProvider` use the item presentation

One possible future improvement is to add item presentations for all Pkl nodes, and to get rid of `fun PklExpr.toDisplayText`. But, this is quite a large change and out of scope for this PR.

Sample:

<img width="1136" height="375" alt="Screenshot 2026-05-01 at 8 51 21 AM" src="https://github.com/user-attachments/assets/f7177af5-bb8d-48e0-9f0a-59a953106593" />
