### PR TITLE
Properly flow type `Any.getClass()` calls

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/annotator/PklStringLiteralAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklStringLiteralAnnotator.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.intellij.psi.PsiElement
 import org.pkl.intellij.intention.PklRedundantStringInterpolationQuickFix
 import org.pkl.intellij.psi.*
 import org.pkl.intellij.resolve.ResolveVisitors
+import org.pkl.intellij.type.computeThisType
 import org.pkl.intellij.util.canModify
 import org.pkl.intellij.util.currentFile
 import org.pkl.intellij.util.currentProject
@@ -50,15 +51,17 @@ class PklStringLiteralAnnotator : PklAnnotator() {
 
         when (expr) {
           is PklUnqualifiedAccessExpr -> {
+            val recieverType = expr.computeThisType(base, emptyMap(), context)
             val visitor =
               ResolveVisitors.typeOfFirstElementNamed(
                 expr.memberName.identifier.text,
                 null,
                 base,
                 expr.isNullSafeAccess,
-                false
+                false,
+                recieverType,
               )
-            val type = expr.resolve(base, null, mapOf(), visitor, context)
+            val type = expr.resolve(base, recieverType, mapOf(), visitor, context)
             if (type.isSubtypeOf(base.stringType, base, context)) {
               warn(element, holder)
             }

--- a/src/main/kotlin/org/pkl/intellij/documentation/PklDocumentationProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/documentation/PklDocumentationProvider.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,18 +307,20 @@ class PklDocumentationProvider : AbstractDocumentationProvider() {
         // support flow typing when showing documentation for nodes that navigate to ther nodes
         // (e.g. they aren't param declarations or class properties)
         originalElement?.isAncestor(element) == false -> {
+          val thisType = element.computeThisType(base, mapOf(), context)
           val visitor =
             ResolveVisitors.typeOfFirstElementNamed(
               name,
               null,
               element.project.pklBaseModule,
               isNullSafeAccess = false,
-              preserveUnboundTypeVars = false
+              preserveUnboundTypeVars = false,
+              thisType,
             )
           val computedType =
             Resolvers.resolveUnqualifiedAccess(
               originalElement,
-              element.computeThisType(base, mapOf(), context),
+              thisType,
               true,
               element.project.pklBaseModule,
               mapOf(),

--- a/src/main/kotlin/org/pkl/intellij/psi/PklBaseModule.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklBaseModule.kt
@@ -86,6 +86,7 @@ class PklBaseModule(private val stdLib: PklStdLib) {
   val regexConstructor: PklClassMethod = method("Regex")
 
   val anyType: Type.Class = classType("Any")
+  val anyGetClassMethod: PklClassMethod = anyType.psi.methods.first { it.name == "getClass" }
   val nullType: Type.Class = classType("Null")
   val booleanType: Type.Class = classType("Boolean")
   val numberType: Type.Class = classType("Number")

--- a/src/main/kotlin/org/pkl/intellij/resolve/ResolveVisitors.kt
+++ b/src/main/kotlin/org/pkl/intellij/resolve/ResolveVisitors.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,8 @@ object ResolveVisitors {
     argumentList: PklArgumentList?,
     base: PklBaseModule,
     isNullSafeAccess: Boolean,
-    preserveUnboundTypeVars: Boolean
+    preserveUnboundTypeVars: Boolean,
+    receiverType: Type,
   ): FlowTypingResolveVisitor<Type> =
     object : FlowTypingResolveVisitor<Type> {
       var isNonNull = false
@@ -169,7 +170,7 @@ object ResolveVisitors {
                 .resolve(context)
                 .computeResolvedImportType(base, bindings, preserveUnboundTypeVars, context)
             is PklTypeParameter -> bindings[element] ?: Type.Unknown
-            is PklMethod -> computeMethodReturnType(element, bindings, context)
+            is PklMethod -> computeMethodReturnType(element, bindings, context, receiverType)
             is PklClass -> base.classType.withTypeArguments(Type.Class(element))
             is PklTypeAlias -> base.typeAliasType.withTypeArguments(Type.alias(element, context))
             is PklNavigableElement ->
@@ -219,7 +220,8 @@ object ResolveVisitors {
       private fun computeMethodReturnType(
         method: PklMethod,
         bindings: TypeParameterBindings,
-        context: PklProject?
+        context: PklProject?,
+        receiverType: Type,
       ): Type {
         return when (method) {
           // infer return type of `base#Map()` from arguments (type signature is too weak)
@@ -251,6 +253,11 @@ object ResolveVisitors {
               }
               Type.Class(base.mapType.psi, listOf(keyType, valueType))
             }
+          }
+          base.anyGetClassMethod -> {
+            base.classType.withTypeArguments(
+              receiverType.toClassType(base, context) ?: receiverType
+            )
           }
           else -> {
             val typeParameterList = method.typeParameterList

--- a/src/main/kotlin/org/pkl/intellij/type/ComputeDefinitionType.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/ComputeDefinitionType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,8 @@ fun PsiElement?.computeResolvedImportType(
                     null,
                     base,
                     false,
-                    preserveUnboundTypeVars
+                    preserveUnboundTypeVars,
+                    receiverType,
                   )
                 Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor, context)
               }
@@ -86,7 +87,8 @@ fun PsiElement?.computeResolvedImportType(
             null,
             base,
             isNullSafeAccess = false,
-            preserveUnboundTypeVars = false
+            preserveUnboundTypeVars = false,
+            receiverClassType,
           )
         if (
           Resolvers.visitSatisfiedCondition(cond, bindings, visitor, context) ||

--- a/src/main/kotlin/org/pkl/intellij/type/ComputeExprType.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/ComputeExprType.kt
@@ -76,37 +76,43 @@ private fun PsiElement.doComputeExprType(
   return RecursionManager.doPreventingRecursion(this, false) {
     when (this) {
       is PklUnqualifiedAccessExpr -> {
+        val thisType = computeThisType(base, bindings, context)
         val visitor =
           ResolveVisitors.typeOfFirstElementNamed(
             memberNameText,
             argumentList,
             base,
             isNullSafeAccess,
-            false
+            false,
+            thisType,
           )
-        resolve(base, null, bindings, visitor, context)
+        resolve(base, thisType, bindings, visitor, context)
       }
       is PklQualifiedAccessExpr -> {
+        val receiverType = receiverExpr.computeExprType(base, bindings, context)
         val visitor =
           ResolveVisitors.typeOfFirstElementNamed(
             memberNameText,
             argumentList,
             base,
             isNullSafeAccess,
-            false
+            false,
+            receiverType,
           )
-        resolve(base, null, bindings, visitor, context)
+        resolve(base, receiverType, bindings, visitor, context)
       }
       is PklSuperAccessExpr -> {
+        val thisType = computeThisType(base, bindings, context)
         val visitor =
           ResolveVisitors.typeOfFirstElementNamed(
             memberNameText,
             argumentList,
             base,
             isNullSafeAccess,
-            false
+            false,
+            thisType,
           )
-        resolve(base, null, bindings, visitor, context)
+        resolve(base, thisType, bindings, visitor, context)
       }
       is PklTrueLiteral,
       is PklFalseLiteral -> base.booleanType


### PR DESCRIPTION
This makes some parts of #181 much nicer (e.g. flow typing on a reference rooted to a module type)