### PR TITLE
Gracefully handle glob patterns that match large result sets

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 assertj = "3.27.7"
 # GoLand version to verify against. Use latest version.
 # https://www.jetbrains.com/go/download/#section=mac
-goLand = "2024.3"
+goLand = "2024.3.3"
 grammarKit = "2023.3"
 # https://github.com/JetBrains/gradle-grammar-kit-plugin
 grammarKitPlugin = "2023.3.0.3"
@@ -11,7 +11,7 @@ grammarKitPlugin = "2023.3.0.3"
 intellij = "2024.3.3"
 # IntelliJ version to run against (`runIde` task). Use latest version.
 # https://www.jetbrains.com/idea/download/#section=mac
-intellijRunIde = "2024.3"
+intellijRunIde = "2024.3.3"
 intellijPlugin = "2.16.0"
 intellijSinceBuild = "243"
 # set to "999.*" to disable upper bound

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklModuleUriAndVersionAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklModuleUriAndVersionAnnotator.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.packages.dto.Version
 import org.pkl.intellij.packages.pklPackageService
 import org.pkl.intellij.psi.*
+import org.pkl.intellij.util.GlobResolver
 import org.pkl.intellij.util.currentProject
 import org.pkl.intellij.util.escapeXml
 import org.pkl.intellij.util.parseUriOrNull
@@ -320,11 +321,25 @@ class PklModuleUriAndVersionAnnotator : PklAnnotator() {
 
     for ((index, reference) in references.withIndex()) {
       if (reference !is PklModuleUriReference) return
-      val resolved = reference.resolveGlob(context) ?: return
-      if (index == 0 && checkDependencyNotation(element, reference, resolved, holder, context)) {
+      val resolved = reference.resolveGlob(context) ?: continue
+      if (resolved.exceededMaxElements) {
+        val message =
+          "This glob pattern segment matches too many modules. Only the first ${GlobResolver.MAX_GLOB_ELEMENTS} is shown."
+        createAnnotation(
+          HighlightSeverity.INFORMATION,
+          reference.rangeInElement.shiftRight(element.textOffset),
+          message,
+          message,
+          holder
+        )
+      }
+      if (
+        index == 0 &&
+          checkDependencyNotation(element, reference, resolved.elements, holder, context)
+      ) {
         return
       }
-      if (resolved.isEmpty()) {
+      if (resolved.elements.isEmpty()) {
         createAnnotation(
           HighlightSeverity.WARNING,
           reference.rangeInElement.shiftRight(element.textOffset),
@@ -335,7 +350,7 @@ class PklModuleUriAndVersionAnnotator : PklAnnotator() {
           element
         )
       }
-      if (index == references.lastIndex && resolved.any { it !is PklModule }) {
+      if (index == references.lastIndex && resolved.elements.any { it !is PklModule }) {
         createAnnotation(
           HighlightSeverity.WARNING,
           reference.rangeInElement.shiftRight(element.textOffset),

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklModuleUriAndVersionAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklModuleUriAndVersionAnnotator.kt
@@ -324,7 +324,7 @@ class PklModuleUriAndVersionAnnotator : PklAnnotator() {
       val resolved = reference.resolveGlob(context) ?: continue
       if (resolved.exceededMaxElements) {
         val message =
-          "This glob pattern segment matches too many modules. Only the first ${GlobResolver.MAX_GLOB_ELEMENTS} is shown."
+          "This glob pattern segment matches too many modules. Only the first ${GlobResolver.MAX_GLOB_ELEMENTS} are shown."
         createAnnotation(
           HighlightSeverity.INFORMATION,
           reference.rangeInElement.shiftRight(element.textOffset),

--- a/src/main/kotlin/org/pkl/intellij/psi/Extensions.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/Extensions.kt
@@ -37,6 +37,7 @@ import org.pkl.intellij.packages.pklPackageService
 import org.pkl.intellij.packages.pklProjectService
 import org.pkl.intellij.psi.PklElementTypes.IMPORT_GLOB
 import org.pkl.intellij.type.*
+import org.pkl.intellij.util.GlobResolver
 import org.pkl.intellij.util.appendNumericSuffix
 import org.pkl.intellij.util.inferImportPropertyName
 import org.pkl.intellij.util.unexpectedType
@@ -411,14 +412,8 @@ fun PklModuleUri.resolve(context: PklProject?): PklModule? =
       as? PklModule?
   }
 
-fun resolveModuleUriGlob(element: PklModuleUri, context: PklProject?): List<PklModule> =
-  element.escapedContent
-    ?.let { PklModuleUriReference.resolveGlob(it, it, element, context) }
-    ?.filterIsInstance<PklModule>()
-    ?: emptyList()
-
-fun PklModuleUri.resolveGlob(context: PklProject?): List<PklModule> =
-  resolveModuleUriGlob(this, context)
+private fun PklModuleUri.resolveGlob(context: PklProject?): GlobResolver.GlobResult? =
+  escapedContent?.let { PklModuleUriReference.resolveGlob(it, it, this, context) }
 
 /**
  * Finds or inserts (in sort order) an import for [uri] and returns its member name. Returns `null`
@@ -492,17 +487,21 @@ class SimpleModuleResolutionResult(val resolved: PklModule?) : ModuleResolutionR
   }
 }
 
-class GlobModuleResolutionResult(val resolved: List<PklModule>) : ModuleResolutionResult() {
+class GlobModuleResolutionResult(val resolved: GlobResolver.GlobResult) : ModuleResolutionResult() {
+  companion object {
+    val EMPTY = GlobModuleResolutionResult(GlobResolver.GlobResult(emptyList(), false))
+  }
+
   override fun computeResolvedImportType(
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     preserveUnboundedVars: Boolean,
     context: PklProject?
   ): Type {
-    if (resolved.isEmpty())
+    if (resolved.exceededMaxElements || resolved.elements.isEmpty())
       return base.mappingType.withTypeArguments(base.stringType, base.moduleType)
     val allTypes =
-      resolved.map {
+      resolved.elements.map {
         it.computeResolvedImportType(
           base,
           bindings,
@@ -537,9 +536,15 @@ class GlobModuleResolutionResult(val resolved: List<PklModule>) : ModuleResoluti
   }
 }
 
-fun PklImportBase.resolve(context: PklProject?): ModuleResolutionResult =
-  if (isGlob) GlobModuleResolutionResult(moduleUri?.resolveGlob(context) ?: emptyList())
-  else SimpleModuleResolutionResult(moduleUri?.resolve(context))
+fun PklImportBase.resolve(context: PklProject?): ModuleResolutionResult {
+  return if (isGlob) {
+    val moduleUri = moduleUri ?: return GlobModuleResolutionResult.EMPTY
+    val result = moduleUri.resolveGlob(context) ?: return GlobModuleResolutionResult.EMPTY
+    GlobModuleResolutionResult(result)
+  } else {
+    SimpleModuleResolutionResult(moduleUri?.resolve(context))
+  }
+}
 
 fun PklImportBase.resolveModules(context: PklProject?): List<PklModule> =
   resolve(context).let { result ->
@@ -547,7 +552,9 @@ fun PklImportBase.resolveModules(context: PklProject?): List<PklModule> =
       is SimpleModuleResolutionResult -> result.resolved?.let(::listOf) ?: emptyList()
       else -> {
         result as GlobModuleResolutionResult
-        result.resolved
+        val resolved = result.resolved
+        if (resolved.exceededMaxElements) emptyList()
+        else resolved.elements.filterIsInstance<PklModule>()
       }
     }
   }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -42,7 +42,6 @@ import org.pkl.intellij.util.*
 /** A reference within a module URI. May reference a package/directory or file. */
 class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
   PsiPolyVariantReferenceBase<PklModuleUri>(uri, rangeInElement),
-  PsiPolyVariantReference,
   UserDataHolder,
   PklReference {
   val moduleUri: String = element.stringConstant.content.text

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -41,9 +41,7 @@ import org.pkl.intellij.util.*
 
 /** A reference within a module URI. May reference a package/directory or file. */
 class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
-  PsiPolyVariantReferenceBase<PklModuleUri>(uri, rangeInElement),
-  UserDataHolder,
-  PklReference {
+  PsiPolyVariantReferenceBase<PklModuleUri>(uri, rangeInElement), UserDataHolder, PklReference {
   val moduleUri: String = element.stringConstant.content.text
 
   private val project = uri.project

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModuleUriReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,23 +41,16 @@ import org.pkl.intellij.util.*
 
 /** A reference within a module URI. May reference a package/directory or file. */
 class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
-  PsiReferenceBase<PklModuleUri>(uri, rangeInElement),
+  PsiPolyVariantReferenceBase<PklModuleUri>(uri, rangeInElement),
   PsiPolyVariantReference,
   UserDataHolder,
   PklReference {
-
   val moduleUri: String = element.stringConstant.content.text
 
   private val project = uri.project
 
   private val targetUri: String =
     moduleUri.substring(0, rangeInElement.endOffset - element.stringConstant.stringStart.textLength)
-
-  private class UriResolveResult(private val element: PsiElement) : ResolveResult {
-    override fun getElement(): PsiElement = element
-
-    override fun isValidResult(): Boolean = true
-  }
 
   private val isGlobImport = (uri.parent as? PklImportBase)?.isGlob ?: false
 
@@ -84,15 +77,14 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
         )
     }
 
-  override fun resolve(): PsiElement? = resolveContextual(null)
-
-  fun resolveGlob(context: PklProject?): List<PsiFileSystemItem>? {
+  fun resolveGlob(context: PklProject?): GlobResolver.GlobResult? {
     return resolveGlob(targetUri, moduleUri, element, context)
   }
 
   override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
     if (isGlobImport) {
-      return resolveGlob(null)?.map(::UriResolveResult)?.toTypedArray() ?: emptyArray()
+      val resolved = resolveGlob(null) ?: return emptyArray()
+      return resolved.elements.map(::PsiElementResolveResult).toTypedArray()
     }
     return resolve(
         targetUri,
@@ -102,7 +94,7 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
         project,
         null
       )
-      ?.let { arrayOf(UriResolveResult(it)) }
+      ?.let { arrayOf(PsiElementResolveResult(it)) }
       ?: emptyArray()
   }
 
@@ -200,7 +192,7 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
     )
 
     private val resolvedGlobProvider:
-      ParameterizedCachedValueProvider<List<PsiFileSystemItem>, ResolveGlobParams> =
+      ParameterizedCachedValueProvider<GlobResolver.GlobResult, ResolveGlobParams> =
       ParameterizedCachedValueProvider { (targetUriString, moduleUriString, element, context) ->
         val result =
           doResolveGlob(targetUriString, moduleUriString, element, context)
@@ -223,7 +215,7 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       moduleUriString: String,
       element: PklModuleUri,
       context: PklProject?
-    ): List<PsiFileSystemItem>? =
+    ): GlobResolver.GlobResult? =
       CachedValuesManager.getManager(element.project)
         .getParameterizedCachedValue(
           element,
@@ -241,7 +233,7 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       moduleUriString: String,
       element: PklModuleUri,
       context: PklProject?
-    ): List<PsiFileSystemItem>? {
+    ): GlobResolver.GlobResult? {
       val sourceFile = element.containingFile
       // triple-dot URI's are not supported
       if (targetUriString.startsWith("...")) {
@@ -253,10 +245,6 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
       val psiManager = PsiManager.getInstance(project)
 
       val fileManager = VirtualFileManager.getInstance()
-      val toFileSystemItem = { virtualFile: VirtualFile ->
-        if (virtualFile.isDirectory) psiManager.findDirectory(virtualFile)
-        else psiManager.findFile(virtualFile)
-      }
 
       val projectRootManager = ProjectRootManager.getInstance(project)
       val fileIndex = projectRootManager.fileIndex
@@ -274,7 +262,13 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
             when {
               targetPath.startsWith('/') -> {
                 val fileRoot = fileManager.findFileByUrl("file:///") ?: return null
-                GlobResolver.resolveAbsoluteGlob(fileRoot, targetPath, isPartialUri, listChildren)
+                GlobResolver.resolveAbsoluteGlob(
+                  fileRoot,
+                  targetPath,
+                  isPartialUri,
+                  project,
+                  listChildren
+                )
               }
               targetPath.startsWith('@') -> {
                 getDependencyRoot(project, targetPath, element.enclosingModule, context)?.let { root
@@ -284,6 +278,7 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
                     root,
                     effectiveTargetString,
                     isPartialUri,
+                    project,
                     listChildren
                   )
                 }
@@ -293,28 +288,34 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
                   virtualFile.parent,
                   targetUriString,
                   isPartialUri,
+                  project,
                   listChildren
                 )
             }
-          return resolved?.mapNotNull(toFileSystemItem)
+          resolved
         }
         "modulepath" -> {
           val roots = sourceFile.findSourceAndClassesRoots()
           if (roots.isEmpty()) return null
           val listChildren = { it: VirtualFile -> listClassPathChildren(it, roots, fileIndex) }
           val targetPath = targetUri.path ?: return null
-          val resolved =
-            if (targetPath.startsWith('/')) {
-              GlobResolver.resolveAbsoluteGlob(roots[0], targetPath, isPartialUri, listChildren)
-            } else {
-              GlobResolver.resolveRelativeGlob(
-                virtualFile.parent,
-                targetUriString,
-                isPartialUri,
-                listChildren
-              )
-            }
-          return resolved.mapNotNull(toFileSystemItem)
+          if (targetPath.startsWith('/')) {
+            GlobResolver.resolveAbsoluteGlob(
+              roots[0],
+              targetPath,
+              isPartialUri,
+              project,
+              listChildren
+            )
+          } else {
+            GlobResolver.resolveRelativeGlob(
+              virtualFile.parent,
+              targetUriString,
+              isPartialUri,
+              project,
+              listChildren
+            )
+          }
         }
         "package" -> {
           if (targetUri.fragment?.startsWith('/') != true) {
@@ -325,9 +326,13 @@ class PklModuleUriReference(uri: PklModuleUri, rangeInElement: TextRange) :
               ?: return null
           val listChildren = { it: VirtualFile -> it.children }
           val targetPath = targetUri.fragment ?: return null
-          val resolved =
-            GlobResolver.resolveAbsoluteGlob(packageRoot, targetPath, isPartialUri, listChildren)
-          return resolved.mapNotNull(toFileSystemItem)
+          GlobResolver.resolveAbsoluteGlob(
+            packageRoot,
+            targetPath,
+            isPartialUri,
+            project,
+            listChildren
+          )
         }
         else -> null
       }

--- a/src/main/kotlin/org/pkl/intellij/util/GlobResolver.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/GlobResolver.kt
@@ -15,13 +15,17 @@
  */
 package org.pkl.intellij.util
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFileSystemItem
+import com.intellij.psi.PsiManager
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import kotlin.collections.ArrayList
 
 object GlobResolver {
+  data class GlobResult(val elements: List<PsiFileSystemItem>, val exceededMaxElements: Boolean)
 
   private val cache = Collections.synchronizedMap(WeakHashMap<String, Pattern>())
 
@@ -33,6 +37,8 @@ object GlobResolver {
    * and `..`)
    */
   private const val MAX_LIST_ELEMENTS = 16384
+
+  const val MAX_GLOB_ELEMENTS = 300
 
   private fun getNextChar(pattern: String, i: Int): Char =
     if (i >= pattern.length - 1) NULL else pattern[i + 1]
@@ -279,6 +285,8 @@ object GlobResolver {
    * @param listElementCallCount The number of times we have listed children
    * @param isPartial Whether [globPatternParts] represents the whole URI
    * @param result The return value
+   * @return a boolean indicating whether the number of elements in the glob exceeded
+   *   [MAX_GLOB_ELEMENTS]
    */
   private fun expandGlob(
     globPatternParts: List<String>,
@@ -287,8 +295,9 @@ object GlobResolver {
     listElementCallCount: AtomicInteger,
     isPartial: Boolean,
     listChildren: (VirtualFile) -> Array<VirtualFile>,
-    result: MutableList<VirtualFile>
-  ) {
+    psiManager: PsiManager,
+    result: MutableList<PsiFileSystemItem>
+  ): Boolean {
     val patternPart = globPatternParts[idx]
     val isLeaf = idx == globPatternParts.size - 1
     // no expanding needed, carry on
@@ -297,70 +306,108 @@ object GlobResolver {
         when (patternPart) {
           "." -> currentDir
           ".." -> currentDir.parent
-          else -> listChildren(currentDir).find { it.name == patternPart } ?: return
+          else -> listChildren(currentDir).find { it.name == patternPart } ?: return false
         }
       if (isLeaf) {
-        result.add(child)
-        return
+        if (result.size == MAX_GLOB_ELEMENTS) return true
+        child.toFileSystemItem(psiManager)?.let { result.add(it) }
+        return false
       }
       if (child.isDirectory) {
-        expandGlob(
+        return expandGlob(
           globPatternParts,
           idx + 1,
           child,
           listElementCallCount,
           isPartial,
           listChildren,
+          psiManager,
           result
         )
       }
     } else {
       val expandedFiles =
         expandGlobPart(currentDir, patternPart, listElementCallCount, listChildren, isPartial)
-          ?: return
+          ?: return false
       for (file in expandedFiles) {
         if (isLeaf) {
-          result.add(file)
+          if (result.size == MAX_GLOB_ELEMENTS) return true
+          file.toFileSystemItem(psiManager)?.let { result.add(it) }
         } else if (file.isDirectory) {
-          expandGlob(
-            globPatternParts,
-            idx + 1,
-            file,
-            listElementCallCount,
-            isPartial,
-            listChildren,
-            result
-          )
+          val exceededMaxElements =
+            expandGlob(
+              globPatternParts,
+              idx + 1,
+              file,
+              listElementCallCount,
+              isPartial,
+              listChildren,
+              psiManager,
+              result
+            )
+          if (exceededMaxElements) return true
         }
       }
     }
+    return false
+  }
+
+  fun VirtualFile.toFileSystemItem(psiManager: PsiManager): PsiFileSystemItem? {
+    return if (isDirectory) psiManager.findDirectory(this) else psiManager.findFile(this)
   }
 
   fun resolveRelativeGlob(
     enclosingDirectory: VirtualFile,
     globPattern: String,
     isPartial: Boolean,
+    project: Project,
     listChildren: (VirtualFile) -> Array<VirtualFile>
-  ): List<VirtualFile> {
-    if (globPattern.isEmpty()) return listOf(enclosingDirectory)
-    val result = ArrayList<VirtualFile>()
+  ): GlobResult {
+    val psiManager = PsiManager.getInstance(project)
+    if (globPattern.isEmpty()) {
+      return GlobResult(listOfNotNull(enclosingDirectory.toFileSystemItem(psiManager)), false)
+    }
+    val result = ArrayList<PsiFileSystemItem>()
     val globParts = globPattern.split("/")
-    if (globParts.isEmpty()) return emptyList()
-    expandGlob(globParts, 0, enclosingDirectory, AtomicInteger(0), isPartial, listChildren, result)
-    return result
+    if (globParts.isEmpty()) return GlobResult(emptyList(), false)
+    val exceededMaxElements =
+      expandGlob(
+        globParts,
+        0,
+        enclosingDirectory,
+        AtomicInteger(0),
+        isPartial,
+        listChildren,
+        psiManager,
+        result
+      )
+    return GlobResult(result, exceededMaxElements)
   }
 
   fun resolveAbsoluteGlob(
     rootFile: VirtualFile,
     globPattern: String,
     isPartial: Boolean,
+    project: Project,
     listChildren: (VirtualFile) -> Array<VirtualFile>
-  ): List<VirtualFile> {
-    if (globPattern == "/") return listOf(rootFile)
-    val result = ArrayList<VirtualFile>()
+  ): GlobResult {
+    val psiManager = PsiManager.getInstance(project)
+    if (globPattern == "/")
+      return GlobResult(listOfNotNull(rootFile.toFileSystemItem(psiManager)), false)
+    val result = ArrayList<PsiFileSystemItem>()
     val globParts = globPattern.split("/").drop(1)
-    if (globParts.isEmpty()) return emptyList()
-    expandGlob(globParts, 0, rootFile, AtomicInteger(0), isPartial, listChildren, result)
-    return result
+    if (globParts.isEmpty()) return GlobResult(emptyList(), false)
+    val exceededMaxElements =
+      expandGlob(
+        globParts,
+        0,
+        rootFile,
+        AtomicInteger(0),
+        isPartial,
+        listChildren,
+        psiManager,
+        result
+      )
+    return GlobResult(result, exceededMaxElements)
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -143,6 +143,8 @@
     <generatedSourcesFilter implementation="org.pkl.intellij.PklGeneratedSourcesFilter" />
     <fileType name="Pkl" implementationClass="org.pkl.intellij.PklFileType"
               fieldName="INSTANCE" language="Pkl" extensions="pkl;pcf" fileNames="PklProject"/>
+    <!--suppress PluginXmlI18n -->
+    <notificationGroup displayType="BALLOON" id="PklModuleUriReference" />
     <externalIconProvider key="PklProject" implementationClass="org.pkl.intellij.packages.PklExternalSystemIconProvider"/>
     <editorNotificationProvider implementation="org.pkl.intellij.notification.PklSyncProjectNotificationProvider" />
     <editorNotificationProvider implementation="org.pkl.intellij.notification.PklToolchainNotificationProvider" />


### PR DESCRIPTION
Glob patterns that expand to too many files will slow the editor to a crawl, especially around type resolution, and also when using "cmd + click", which are run in the editor thread.

This changes the following:

* Stop expanding a glob once 300 elements has been reached
* Show a diagnostics hint that the glob is too large
* Only provide goto definitions for the first 300
* Simplify type analysis to just `Mapping<String, Module>`

NOTE: 300 elements was picked arbitrarily; I just picked a number that preserves snappiness on my machine.
Possibly, this can become a user-configurable setting.