### PR TITLE
feat: mirror CLI cache and editor-support fallbacks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,27 @@ Compatible with **IntelliJ 2023.1** or higher and **Pkl 0.25.0** or higher.
 
 Follow {uri-docs-installation}[installation instructions] and check out the {uri-docs-features}[feature overview].
 
+== Cached packages and editor-support data
+
+The plugin looks up cached Pkl packages and the downloaded `pkl` CLI under the same OS-appropriate locations that the Pkl CLI uses:
+
+[cols="1,2,2,2",options="header"]
+|===
+| Concern | Unix (Linux/macOS) | Windows | Legacy fallback
+
+| Package cache
+| `~/.cache/pkl`
+| `%LOCALAPPDATA%/pkl/cache`
+| `~/.pkl/cache`
+
+| Downloaded CLI (default)
+| `~/.local/share/pkl/editor-support/bin/pkl`
+| `%LOCALAPPDATA%/pkl/editor-support/bin/pkl.exe`
+| `~/.pkl/editor-support/bin/pkl`
+|===
+
+If a legacy `~/.pkl/...` location already exists, the plugin keeps using it so existing setups don't need to migrate. See the link:https://pkl-lang.org/main/current/release-notes/0.32.html[Pkl 0.32 release notes] for the full mapping.
+
 == Community
 
 We'd love to hear from you!

--- a/src/main/kotlin/org/pkl/intellij/action/PklDownloadPklCliAction.kt
+++ b/src/main/kotlin/org/pkl/intellij/action/PklDownloadPklCliAction.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,18 +196,34 @@ class PklDownloadPklCliAction(
         }
       }
 
-    private fun defaultExecutableName(): String =
-      if (System.getProperty("os.name").lowercase().contains("win")) "pkl.exe" else "pkl"
+    private fun defaultExecutableName(): String = if (isWindows()) "pkl.exe" else "pkl"
 
-    private fun suggestedDownloadPath(): String =
-      Paths.get(
-          System.getProperty("user.home"),
-          ".pkl",
-          "editor-support",
-          "bin",
-          defaultExecutableName()
-        )
-        .toString()
+    private fun isWindows(): Boolean = System.getProperty("os.name").lowercase().contains("win")
+
+    /**
+     * Suggested filesystem path for the downloaded Pkl CLI.
+     *
+     * Mirrors the editor-support layout from `org.pkl.core.util.IoUtils#getDefaultModuleCacheDir`:
+     * Unix uses `~/.local/share/pkl/editor-support/bin/pkl`, Windows uses
+     * `%LOCALAPPDATA%/pkl/editor-support/bin/pkl.exe`. Falls back to the legacy
+     * `~/.pkl/editor-support/bin/<exe>` when that directory already exists, so a user who
+     * downloaded the CLI to the old location keeps seeing it as the default.
+     */
+    private fun suggestedDownloadPath(): String {
+      val home = System.getProperty("user.home")
+      val executable = defaultExecutableName()
+      val legacy = Paths.get(home, ".pkl", "editor-support", "bin", executable)
+      if (Files.exists(legacy)) return legacy.toString()
+      val preferred: Path? =
+        if (isWindows()) {
+          System.getenv("LOCALAPPDATA")
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { Paths.get(it, "pkl", "editor-support", "bin", executable) }
+        } else {
+          Paths.get(home, ".local", "share", "pkl", "editor-support", "bin", executable)
+        }
+      return (preferred ?: legacy).toString()
+    }
   }
 }
 

--- a/src/main/kotlin/org/pkl/intellij/util/Util.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/Util.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderEnumerator
 import com.intellij.openapi.util.ModificationTracker
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -73,11 +74,26 @@ private const val SIGNIFICAND_BITS = 52
 
 private const val IMPLICIT_BIT: Long = SIGNIFICAND_MASK + 1
 
-val pklDir: VirtualFile?
-  get() = VfsUtil.getUserHomeDir()?.findChild(".pkl")
-
+/**
+ * The default Pkl package cache directory. Prefers the OS-appropriate location – `~/.cache/pkl` on
+ * Unix, `%LOCALAPPDATA%/pkl/cache` on Windows – falling back to the legacy `~/.pkl/cache` when it
+ * already exists. New setups land in the new location; existing setups keep working without
+ * migration.
+ *
+ * Keep in sync with `org.pkl.core.util.IoUtils#getDefaultModuleCacheDir`.
+ */
 val pklCacheDir: VirtualFile?
-  get() = pklDir?.findChild("cache")
+  get() {
+    val home = VfsUtil.getUserHomeDir() ?: return null
+    val newLocation: VirtualFile? =
+      if (SystemInfo.isWindows) {
+        val localAppData = System.getenv("LOCALAPPDATA")?.takeIf { it.isNotEmpty() }
+        localAppData?.let { home.fileSystem.findFileByPath("$it/pkl/cache") }
+      } else {
+        home.findFileByRelativePath(".cache/pkl")
+      }
+    return newLocation ?: home.findFileByRelativePath(".pkl/cache")
+  }
 
 interface CacheDir {
   val file: VirtualFile


### PR DESCRIPTION
Look up cached Pkl packages and the suggested CLI download path under the OS-appropriate locations the CLI uses: `~/.cache/pkl` and `~/.local/share/pkl/editor-support` on Unix, and `%LOCALAPPDATA%/pkl/...` on Windows.

Fall back to the legacy `~/.pkl/cache` and `~/.pkl/editor-support` when they already exist, so existing setups keep working without migration.

This PR is aligned with the path conventions in [apple/pkl#1674](https://github.com/apple/pkl/pull/1674) (targeting Pkl 0.32). The fallback logic is replicated locally with a `keep in sync with org.pkl.core.util.IoUtils#getDefaultModuleCacheDir` comment, mirroring the pattern `pkl-executor` already uses for `defaultModuleCacheDir`.

Without this, a user who upgrades their CLI to 0.32 and opens IntelliJ would lose visibility of cached packages: the IDE would look in `~/.pkl/cache` while the CLI writes to `~/.cache/pkl`.