### PR TITLE
Fix error around slow operations in EDT

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/notification/PklSyncProjectNotificationProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/notification/PklSyncProjectNotificationProvider.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,39 +53,41 @@ class PklSyncProjectNotificationProvider(project: Project) : EditorNotificationP
     }
   }
 
+  private val noComponent: Function<in FileEditor, out JComponent?> = Function { null }
+
   override fun collectNotificationData(
     project: Project,
     file: VirtualFile
   ): Function<in FileEditor, out JComponent?> {
+    if (ScratchUtil.isScratch(file)) return noComponent
+    if (!project.pklCli.isAvailable()) return noComponent
+    val psiFile = PsiManager.getInstance(project).findFile(file)
+    if (psiFile !is PklModule) return noComponent
+    // isInPklProject performs a VFS directory walk — must run off EDT here, not in the Function
+    if (!psiFile.isInPklProject) return noComponent
+    val hasPklProject = psiFile.pklProject != null
+    val isOutOfDate = project.pklProjectService.isOutOfDate()
+    val error = if (!hasPklProject) project.pklProjectService.getError(file) else null
     return Function { _ ->
-      if (ScratchUtil.isScratch(file)) return@Function null
-      if (!project.pklCli.isAvailable()) return@Function null
-      val psiFile = PsiManager.getInstance(project).findFile(file)
-      if (psiFile !is PklModule) return@Function null
-      if (!psiFile.isInPklProject) return@Function null
-      if (psiFile.pklProject == null) {
-        return@Function PklEditorNotificationPanel().apply {
-          val error = project.pklProjectService.getError(file)
-          if (error != null) {
-            text = "Project Sync error"
-
-            createActionLabel("View details", "Pkl.ShowSyncError")
-            createActionLabel("Retry", "Pkl.SyncPklProjects")
-          } else {
+      when {
+        !hasPklProject ->
+          PklEditorNotificationPanel().apply {
+            if (error != null) {
+              text = "Project Sync error"
+              createActionLabel("View details", "Pkl.ShowSyncError")
+              createActionLabel("Retry", "Pkl.SyncPklProjects")
+            } else {
+              text = "Sync Pkl project"
+              createActionLabel("Sync", "Pkl.SyncPklProjects")
+            }
+          }
+        isOutOfDate ->
+          PklEditorNotificationPanel().apply {
             text = "Sync Pkl project"
-
             createActionLabel("Sync", "Pkl.SyncPklProjects")
           }
-        }
+        else -> null
       }
-      if (project.pklProjectService.isOutOfDate()) {
-        return@Function PklEditorNotificationPanel().apply {
-          text = "Sync Pkl project"
-
-          createActionLabel("Sync", "Pkl.SyncPklProjects")
-        }
-      }
-      null
     }
   }
 }


### PR DESCRIPTION
Fixes error around "Slow operations are prohibited on EDT."

Original error:

```
java.lang.Throwable: Slow operations are prohibited on EDT. See
  SlowOperations.assertSlowOperationsAreAllowed javadoc.
      at com.intellij.openapi.diagnostic.Logger.error(Logger.java:375)
      at com.intellij.util.SlowOperations.logError(SlowOperations.java:180)
      at
  com.intellij.util.SlowOperations.assertSlowOperationsAreAllowed(SlowOperations.java:128)
      at
  com.intellij.openapi.vfs.newvfs.persistent.FSRecordsImpl.update(FSRecordsImpl.java:789)
      at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.findChildInfo(PersistentF
  SImpl.java:778)
      at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findInPersistence(VirtualDi
  rectoryImpl.java:243)
      at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findChildImpl(VirtualDirect
  oryImpl.java:221)
      at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findChild(VirtualDirectoryI
  mpl.java:132)
      at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findChild(VirtualDirectoryI
  mpl.java:666)
      at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.findChild(VirtualDirectoryI
  mpl.java:63)
      at com.intellij.psi.impl.file.PsiDirectoryImpl.findFile(PsiDirectoryImpl.java:212)
      at org.pkl.intellij.psi.PklModuleImpl._get_pklProjectDir_$lambda$0(PklModuleImpl.kt:277)
      at com.intellij.psi.impl.AbstractPsiCachedValue.doCompute(PsiCachedValueImpl.kt:21)
      at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:304)
      at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
      at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:304)
      at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionMana
  ger.java:124)
      at
  com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:28)
      at
  com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:79)
      at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:305)
      at com.intellij.psi.impl.AbstractPsiCachedValue.getValue(PsiCachedValueImpl.kt:15)
      at
  com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:98)
      at org.pkl.intellij.psi.PklModuleImpl.getPklProjectDir(PklModuleImpl.kt:270)
      at org.pkl.intellij.psi.PklModuleImpl.isInPklProject(PklModuleImpl.kt:257)
      at org.pkl.intellij.notification.PklSyncProjectNotificationProvider.collectNotificationD
  ata$lambda$0(PklSyncProjectNotificationProvider.kt:65)
      at com.intellij.ui.EditorNotificationsImpl$updateEditors$job$1$2.invokeSuspend(EditorNot
  ificationsImpl.kt:286)
      at
  kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
      at
  com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:221)
      at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1$0
  (NonBlockingFlushQueue.kt:334)
      at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgres
  sManager.java:928)
      at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1(N
  onBlockingFlushQueue.kt:333)
      at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
      at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1(Non
  BlockingFlushQueue.kt:330)
      at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunWriteIntentReadA
  ction(NestedLocksThreadingSupport.kt:747)
      at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent(NonBlockingF
  lushQueue.kt:326)
      at com.intellij.openapi.application.impl.NonBlockingFlushQueue.flushNow(NonBlockingFlush
  Queue.kt:305)
      at com.intellij.openapi.application.impl.NonBlockingFlushQueue.FLUSH_NOW$lambda$0(NonBlo
  ckingFlushQueue.kt:167)
      at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:323)
      at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:732)
      at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:711)
      at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:720)
      at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:573)
      at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0$0$0(IdeEventQueue.kt:377)
      at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$0(IdeEventQueue.kt:1110)
      at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuar
  dImpl.java:106)
      at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1110)
      at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0(IdeEventQueue.kt:375)
      at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:415)
      at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.
  java:207)
      at
  java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
      at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.
  java:117)
      at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
      at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
      at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```