### PR TITLE
Add support for goto definition and hover docs

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/documentation/PklDocumentationProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/documentation/PklDocumentationProvider.kt
@@ -17,6 +17,7 @@ package org.pkl.intellij.documentation
 
 import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.lang.documentation.DocumentationMarkup
+import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiDocCommentBase
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -36,6 +37,25 @@ import org.pkl.intellij.type.*
 import org.pkl.intellij.util.escapeXml
 
 class PklDocumentationProvider : AbstractDocumentationProvider() {
+  override fun getCustomDocumentationElement(
+    editor: Editor,
+    file: PsiFile,
+    contextElement: PsiElement?,
+    targetOffset: Int
+  ): PsiElement? {
+    val qualifiedAccessName =
+      contextElement?.parentOfTypes(
+        PklQualifiedAccessNameBase::class, /* stop class */
+        PklObjectBody::class
+      ) as? PklQualifiedAccessNameBase
+        ?: return null
+    val ref = qualifiedAccessName.reference
+    val results = ref.multiResolve(false)
+    if (results.isEmpty()) return null
+    val firstResult = results.first()
+    return firstResult.proxy ?: firstResult.element
+  }
+
   override fun getQuickNavigateInfo(element: PsiElement, originalElement: PsiElement): String? =
     buildString {
       if (!renderSignature(element, originalElement)) return null

--- a/src/main/kotlin/org/pkl/intellij/psi/PklQualifiedAccessReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklQualifiedAccessReference.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,8 +51,6 @@ class PklQualifiedAccessReference(private val accessName: PklQualifiedAccessName
     }
     return accessExpr.resolve(base, null, mapOf(), visitor, context)
   }
-
-  override fun resolve(): PsiElement? = resolveContextual(null)
 
   override fun multiResolve(incompleteCode: Boolean): Array<PklResolveResult> {
     val accessExpr =

--- a/src/main/kotlin/org/pkl/intellij/psi/PklReferenceQualifiedAccessProxy.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklReferenceQualifiedAccessProxy.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.psi
 
+import com.intellij.navigation.ItemPresentation
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.util.TextRange
@@ -26,6 +27,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.impl.FakePsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.util.containers.headTail
 import javax.swing.Icon
 import org.pkl.intellij.PklIcons
 import org.pkl.intellij.packages.dto.PklProject
@@ -37,8 +39,9 @@ class PklReferenceQualifiedAccessProxy(
   private val myName: String,
   val domain: Type,
   val referent: PklType,
-  val myProject: Project
-) : FakePsiElement(), PklElement, PsiNamedElement, Iconable {
+  val myProject: Project,
+  val classProperties: List<PklClassProperty>
+) : FakePsiElement(), PklElement, PsiNamedElement, Iconable, PklDocCommentOwner {
   // `referenceType` guaranteed to exist; PklReferenceQualifiedAccessProxy is only created when
   // pkl:ref is available.
   val type =
@@ -46,7 +49,8 @@ class PklReferenceQualifiedAccessProxy(
 
   override fun <R> accept(visitor: PklVisitor<R>): R? = null
 
-  override fun clone(): Any = PklReferenceQualifiedAccessProxy(myName, domain, referent, myProject)
+  override fun clone(): Any =
+    PklReferenceQualifiedAccessProxy(myName, domain, referent, myProject, classProperties)
 
   override fun getParent(): PsiElement? = null
 
@@ -60,6 +64,22 @@ class PklReferenceQualifiedAccessProxy(
 
   override fun getIcon(open: Boolean): Icon = PklIcons.PROPERTY
 
+  override fun navigate(requestFocus: Boolean) {
+    classProperties.firstOrNull()?.navigate(requestFocus)
+  }
+
+  override fun canNavigate(): Boolean {
+    return true
+  }
+
+  override fun canNavigateToSource(): Boolean {
+    return true
+  }
+
+  override fun getPresentation(): ItemPresentation? {
+    return classProperties.firstOrNull()?.presentation
+  }
+
   fun getLookupElementType(
     base: PklBaseModule,
     bindings: TypeParameterBindings,
@@ -69,6 +89,8 @@ class PklReferenceQualifiedAccessProxy(
       domain,
       referent.toType(base, bindings, context)
     )
+
+  override val docComment: PklDocComment? = classProperties.firstOrNull()?.docComment
 
   object UnknownType : FakePsiElement(), PklUnknownType {
     override fun <R> accept(visitor: PklVisitor<R>): R? = visitor.visitUnknownType(this)
@@ -83,11 +105,14 @@ class PklReferenceQualifiedAccessProxy(
   class UnionType private constructor(val myLeftType: PklType, val myRightType: PklType) :
     FakePsiElement(), PklUnionType {
     companion object {
-      fun create(types: List<PklType>): PklType =
+      fun create(properties: List<PklClassProperty>): PklType =
         when {
-          types.isEmpty() -> UnknownType
-          types.size == 1 -> types.first()
-          else -> types.reduce { t1, t2 -> UnionType(t1, t2) }
+          properties.isEmpty() -> UnknownType
+          properties.size == 1 -> properties.first().type ?: UnknownType
+          else -> {
+            val (head, tail) = properties.headTail()
+            UnionType(head.type ?: UnknownType, create(tail))
+          }
         }
     }
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklReferenceQualifiedAccessProxy.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklReferenceQualifiedAccessProxy.kt
@@ -69,11 +69,11 @@ class PklReferenceQualifiedAccessProxy(
   }
 
   override fun canNavigate(): Boolean {
-    return true
+    return classProperties.firstOrNull()?.canNavigate() ?: false
   }
 
   override fun canNavigateToSource(): Boolean {
-    return true
+    return classProperties.firstOrNull()?.canNavigateToSource() ?: false
   }
 
   override fun getPresentation(): ItemPresentation? {

--- a/src/main/kotlin/org/pkl/intellij/resolve/ResolveVisitors.kt
+++ b/src/main/kotlin/org/pkl/intellij/resolve/ResolveVisitors.kt
@@ -516,7 +516,8 @@ object ResolveVisitors {
         if (name != expectedName) return true
 
         when {
-          element is PklReferenceQualifiedAccessProxy -> return true
+          element is PklReferenceQualifiedAccessProxy ->
+            resultList.addAll(element.classProperties.map { PklResolveResult(it, true, element) })
           element is PklImport ->
             resultList.addAll(element.resolveModules(context).map(::PklResolveResult))
           element is PklTypeParameter && bindings.contains(element) -> {
@@ -589,7 +590,8 @@ fun <R> ResolveVisitor<R>.withoutShadowedElements(): ResolveVisitor<R> =
 
 class PklResolveResult(
   private val pklElement: PklNavigableElement,
-  private val isValidResult: Boolean = true
+  private val isValidResult: Boolean = true,
+  val proxy: PklReferenceQualifiedAccessProxy? = null,
 ) : ResolveResult {
 
   companion object {

--- a/src/main/kotlin/org/pkl/intellij/type/Types.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/Types.kt
@@ -587,10 +587,11 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       visitor: ResolveVisitor<*>,
       context: PklProject?
     ): Boolean {
-      fun visit(name: String, type: PklType): Boolean =
+      if (!psi.isValid) return true
+      fun visit(name: String, type: PklType, classProperties: List<PklClassProperty>): Boolean =
         visitor.visit(
           name,
-          PklReferenceQualifiedAccessProxy(name, domain, type, psi.project),
+          PklReferenceQualifiedAccessProxy(name, domain, type, psi.project, classProperties),
           bindings,
           context
         )
@@ -598,10 +599,14 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       return when {
         !isProperty -> super.visitMembers(false, allowClasses, base, visitor, context)
         referencesUnknown ->
-          visit(visitor.exactName ?: "UNKNOWN", PklReferenceQualifiedAccessProxy.UnknownType)
+          visit(
+            visitor.exactName ?: "UNKNOWN",
+            PklReferenceQualifiedAccessProxy.UnknownType,
+            listOf()
+          )
         visitor.exactName != null -> {
           var isUnknown = false
-          val candidates = mutableSetOf<PklType>()
+          val candidates = mutableListOf<PklClassProperty>()
 
           walkCandidates(referent, base, context) { type, properties ->
             for (prop in properties) {
@@ -611,29 +616,29 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
                   isUnknown = true
                   return@walkCandidates false
                 }
-                candidates.add(propType)
+                candidates.add(prop)
                 return@walkCandidates true
               }
             }
             return@walkCandidates true
           }
 
-          if (isUnknown) visit(visitor.exactName!!, PklReferenceQualifiedAccessProxy.UnknownType)
+          if (isUnknown)
+            visit(visitor.exactName!!, PklReferenceQualifiedAccessProxy.UnknownType, candidates)
           else if (!candidates.isEmpty())
             visit(
               visitor.exactName!!,
-              PklReferenceQualifiedAccessProxy.UnionType.create(candidates.toList())
+              PklReferenceQualifiedAccessProxy.UnionType.create(candidates),
+              candidates
             )
           else true
         }
         else -> {
-          val propertyCandidates = mutableMapOf<String, MutableSet<PklType>>()
+          val propertyCandidates = mutableMapOf<String, MutableList<PklClassProperty>>()
           walkCandidates(referent, base, context) { type, properties ->
             for (prop in properties) {
               if (isViable(prop, type, base, context)) {
-                propertyCandidates
-                  .getOrPut(prop.name) { mutableSetOf() }
-                  .add(prop.type ?: PklReferenceQualifiedAccessProxy.UnknownType)
+                propertyCandidates.getOrPut(prop.name) { mutableListOf() }.add(prop)
               }
             }
             return@walkCandidates true
@@ -641,11 +646,12 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
           for ((propName, candidates) in propertyCandidates) {
             when {
               candidates.any { it is PklUnknownType } ->
-                visit(propName, PklReferenceQualifiedAccessProxy.UnknownType)
+                visit(propName, PklReferenceQualifiedAccessProxy.UnknownType, candidates)
               else ->
                 visit(
                   propName,
-                  PklReferenceQualifiedAccessProxy.UnionType.create(candidates.toList())
+                  PklReferenceQualifiedAccessProxy.UnionType.create(candidates),
+                  candidates
                 )
             }
           }

--- a/src/main/kotlin/org/pkl/intellij/type/Types.kt
+++ b/src/main/kotlin/org/pkl/intellij/type/Types.kt
@@ -645,7 +645,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
           }
           for ((propName, candidates) in propertyCandidates) {
             when {
-              candidates.any { it is PklUnknownType } ->
+              candidates.any { it.type is PklUnknownType } ->
                 visit(propName, PklReferenceQualifiedAccessProxy.UnknownType, candidates)
               else ->
                 visit(

--- a/src/test/kotlin/org/pkl/intellij/resolve/ReferenceResolveTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/resolve/ReferenceResolveTest.kt
@@ -1,0 +1,49 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.resolve
+
+import org.assertj.core.api.Assertions.assertThat
+import org.pkl.intellij.PklFileType
+import org.pkl.intellij.PklTestCase
+import org.pkl.intellij.psi.PklClassProperty
+
+class ReferenceResolveTest : PklTestCase() {
+  fun `test resolve reference`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      import "pkl:ref"
+      
+      class Domain extends ref.Domain
+      
+      class Bird {
+        /// The name of the bird
+        name: String
+      }
+      
+      r: ref.Reference<Domain, Bird>
+      
+      res = r.na<caret>me
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
+    resolved as PklClassProperty
+    assertThat(resolved.name).isEqualTo("name")
+  }
+}


### PR DESCRIPTION
* Make cmd + click go to original property definition
* Show multiple targets in the case of union types
* Show hover docs for original property definition