### PR TITLE
Add quick fix to remove unused imports

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/PklUnusedLocalDefinitionsInspection.kt
+++ b/src/main/kotlin/org/pkl/intellij/PklUnusedLocalDefinitionsInspection.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
 import java.util.*
 import org.pkl.intellij.intention.PklMakeBlankIdentifierQuickFix
+import org.pkl.intellij.intention.PklRemoveImportQuickFix
 import org.pkl.intellij.psi.*
 import org.pkl.intellij.resolve.visitLocalDefinitions
 import org.pkl.intellij.resolve.visitUsedLocalDefinitions
@@ -40,13 +41,19 @@ class PklUnusedLocalDefinitionsInspection : LocalInspectionTool() {
     val usedDefinitions: IdentityHashMap<PklElement, PklElement> = IdentityHashMap()
     visitUsedLocalDefinitions(module, base) { usedDefinitions[it] = it }
 
-    fun report(element: PsiElement?, message: String) {
+    fun report(
+      element: PsiElement?,
+      message: String,
+      extraFixes: Array<LocalQuickFix> = arrayOf()
+    ) {
       if (element == null || element.textMatches("_")) return
       val parent = element.parentOfType<PklTypedIdentifier>()
       val fixes =
         if (parent != null) {
           arrayOf(PklMakeBlankIdentifierQuickFix(parent, isIgnore = true))
-        } else arrayOf()
+        } else {
+          extraFixes
+        }
       problems.add(
         manager.createProblemDescriptor(
           element,
@@ -63,7 +70,8 @@ class PklUnusedLocalDefinitionsInspection : LocalInspectionTool() {
       if (!usedDefinitions.contains(definition)) {
         // TODO: quick fixes
         when (definition) {
-          is PklImport -> report(definition, "Unused import")
+          is PklImport ->
+            report(definition, "Unused import", arrayOf(PklRemoveImportQuickFix(definition)))
           is PklClass -> report(definition.identifier, "Unused class")
           is PklTypeAlias -> report(definition.identifier, "Unused type alias")
           is PklMethod -> report(definition.identifier, "Unused method")

--- a/src/main/kotlin/org/pkl/intellij/intention/PklRemoveImportQuickFix.kt
+++ b/src/main/kotlin/org/pkl/intellij/intention/PklRemoveImportQuickFix.kt
@@ -75,20 +75,21 @@ class PklRemoveImportQuickFix(import: PklImport) :
     if (removedImportTexts.isEmpty()) {
       return IntentionPreviewInfo.EMPTY
     }
-    val sb = StringBuilder()
-    for ((index, text) in removedImportTexts.withIndex()) {
-      if (index > 0) sb.append("<br/>")
-      sb.append("<s>")
-      HtmlSyntaxInfoUtil.appendHighlightedByLexerAndEncodedAsHtmlCodeSnippet(
-        sb,
-        project,
-        PklLanguage,
-        text,
-        1.0f
-      )
-      sb.append("</s>")
+    val html = buildString {
+      for ((index, text) in removedImportTexts.withIndex()) {
+        if (index > 0) append("<br/>")
+        append("<s>")
+        HtmlSyntaxInfoUtil.appendHighlightedByLexerAndEncodedAsHtmlCodeSnippet(
+          this,
+          project,
+          PklLanguage,
+          text,
+          1.0f
+        )
+        append("</s>")
+      }
     }
-    return IntentionPreviewInfo.Html(HtmlChunk.raw(sb.toString()))
+    return IntentionPreviewInfo.Html(HtmlChunk.raw(html))
   }
 
   private fun unusedImports(module: PklModule): List<PklImport> {

--- a/src/main/kotlin/org/pkl/intellij/intention/PklRemoveImportQuickFix.kt
+++ b/src/main/kotlin/org/pkl/intellij/intention/PklRemoveImportQuickFix.kt
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.intention
+
+import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.HtmlChunk
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import java.util.*
+import org.pkl.intellij.PklLanguage
+import org.pkl.intellij.psi.PklImport
+import org.pkl.intellij.psi.PklModule
+import org.pkl.intellij.psi.pklBaseModule
+import org.pkl.intellij.resolve.visitUsedLocalDefinitions
+
+class PklRemoveImportQuickFix(import: PklImport) :
+  LocalQuickFixAndIntentionActionOnPsiElement(import) {
+  @SafeFieldForPreview private val removedImportTexts: List<String>
+
+  init {
+    val module = import.containingFile as? PklModule
+    removedImportTexts = if (module == null) emptyList() else unusedImports(module).map { it.text }
+  }
+
+  override fun getFamilyName(): String = "QuickFix"
+
+  override fun getText(): String = "Remove unused imports"
+
+  override fun invoke(
+    project: Project,
+    file: PsiFile,
+    editor: Editor?,
+    startElement: PsiElement,
+    endElement: PsiElement
+  ) {
+    val module = file as? PklModule ?: return
+    for (import in unusedImports(module)) {
+      (import.nextSibling as? PsiWhiteSpace)?.delete()
+      import.delete()
+    }
+  }
+
+  override fun generatePreview(
+    project: Project,
+    editor: Editor,
+    file: PsiFile
+  ): IntentionPreviewInfo = buildPreview(project)
+
+  override fun generatePreview(
+    project: Project,
+    previewDescriptor: ProblemDescriptor
+  ): IntentionPreviewInfo = buildPreview(project)
+
+  private fun buildPreview(project: Project): IntentionPreviewInfo {
+    if (removedImportTexts.isEmpty()) {
+      return IntentionPreviewInfo.EMPTY
+    }
+    val sb = StringBuilder()
+    for ((index, text) in removedImportTexts.withIndex()) {
+      if (index > 0) sb.append("<br/>")
+      sb.append("<s>")
+      HtmlSyntaxInfoUtil.appendHighlightedByLexerAndEncodedAsHtmlCodeSnippet(
+        sb,
+        project,
+        PklLanguage,
+        text,
+        1.0f
+      )
+      sb.append("</s>")
+    }
+    return IntentionPreviewInfo.Html(HtmlChunk.raw(sb.toString()))
+  }
+
+  private fun unusedImports(module: PklModule): List<PklImport> {
+    val base = module.project.pklBaseModule
+    val usedImports: IdentityHashMap<PklImport, PklImport> = IdentityHashMap()
+    visitUsedLocalDefinitions(module, base) { if (it is PklImport) usedImports[it] = it }
+    return module.imports.filter { !usedImports.contains(it) }.toList()
+  }
+}

--- a/src/test/kotlin/org/pkl/intellij/intention/PklRemoveImportQuickFixTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/intention/PklRemoveImportQuickFixTest.kt
@@ -1,0 +1,122 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.intention
+
+import com.intellij.codeInsight.intention.impl.preview.IntentionPreviewPopupUpdateProcessor
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.openapi.application.ReadAction
+import com.intellij.testFramework.LightProjectDescriptor
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.pkl.intellij.PklUnusedLocalDefinitionsInspection
+
+class PklRemoveImportQuickFixTest {
+  private lateinit var fixture: CodeInsightTestFixture
+
+  @Before
+  fun before() {
+    val factory = IdeaTestFixtureFactory.getFixtureFactory()
+    val base =
+      factory
+        .createLightFixtureBuilder(
+          LightProjectDescriptor.EMPTY_PROJECT_DESCRIPTOR,
+          "sample pkl project"
+        )
+        .fixture
+    fixture = factory.createCodeInsightFixture(base)
+    fixture.setUp()
+    fixture.enableInspections(PklUnusedLocalDefinitionsInspection())
+  }
+
+  @After
+  fun after() {
+    fixture.tearDown()
+  }
+
+  // `math` and `yaml` are used; `json` and `xml` are unused
+  private val source =
+    """
+    import "pkl:json"
+    import "pkl:math"
+    import "pkl:xml"
+    import "pkl:yaml"
+
+    a = math
+    b = yaml
+    """
+      .trimIndent()
+
+  @Test
+  fun `preview lists every unused import that will be removed`() {
+    fixture.configureByText("test.pkl", source)
+    val fix = fixture.getAllQuickFixes().first { it.text == "Remove unused imports" }
+    val info =
+      ReadAction.compute<IntentionPreviewInfo, RuntimeException> {
+        IntentionPreviewPopupUpdateProcessor.getPreviewInfo(
+          fixture.project,
+          fix,
+          fixture.file,
+          fixture.editor,
+          0
+        )
+      }
+    val content = (info as IntentionPreviewInfo.Html).content().toString()
+    assertThat(content).contains("pkl:json")
+    assertThat(content).contains("pkl:xml")
+    assertThat(content).doesNotContain("pkl:math")
+    assertThat(content).doesNotContain("pkl:yaml")
+  }
+
+  @Test
+  fun `preview escapes html in import uris`() {
+    fixture.configureByText("test.pkl", """import "a<b>&c"""")
+    val fix = fixture.getAllQuickFixes().first { it.text == "Remove unused imports" }
+    val info =
+      ReadAction.compute<IntentionPreviewInfo, RuntimeException> {
+        IntentionPreviewPopupUpdateProcessor.getPreviewInfo(
+          fixture.project,
+          fix,
+          fixture.file,
+          fixture.editor,
+          0
+        )
+      }
+    val content = (info as IntentionPreviewInfo.Html).content().toString()
+    assertThat(content).doesNotContain("<b>")
+    assertThat(content).contains("&lt;b&gt;")
+  }
+
+  @Test
+  fun `apply removes all unused imports`() {
+    fixture.configureByText("test.pkl", source)
+    val fix = fixture.getAllQuickFixes().first { it.text == "Remove unused imports" }
+    fixture.launchAction(fix)
+    fixture.checkResult(
+      """
+      import "pkl:math"
+      import "pkl:yaml"
+
+      a = math
+      b = yaml
+      """
+        .trimIndent()
+    )
+  }
+}


### PR DESCRIPTION
The unused import inspection highlights already unused imports. This PR adds a "Remove unused imports" quick fix (Option+Enter) that gets rid of every unused import from the file.

<img width="797" height="180" alt="apple-pkl-intellij" src="https://github.com/user-attachments/assets/10c6facf-3b20-4213-80bc-48e10a2610f2" />

Tested in local env (see screenshot) + unit tests