### PR TITLE
Add autocompletion for overriding abstract methods

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/completion/ImplementMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/completion/ImplementMemberCompletionProvider.kt
@@ -1,0 +1,111 @@
+/**
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.intellij.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parentOfTypes
+import com.intellij.util.ProcessingContext
+import org.pkl.intellij.psi.PklClass
+import org.pkl.intellij.psi.PklClassMember
+import org.pkl.intellij.psi.PklClassMethod
+import org.pkl.intellij.psi.PklModule
+import org.pkl.intellij.psi.PklTypeDefOrModule
+import org.pkl.intellij.psi.createMember
+import org.pkl.intellij.psi.enclosingModule
+import org.pkl.intellij.psi.hasDeclaredMethod
+import org.pkl.intellij.psi.methods
+import org.pkl.intellij.psi.pklBaseModule
+import org.pkl.intellij.util.appendIdentifier
+import org.pkl.intellij.util.insertTemplateAtTodoExprs
+
+private class MemberInsertHandler(private val parentMember: PklClassMember) :
+  InsertHandler<LookupElement> {
+  override fun handleInsert(context: InsertionContext, element: LookupElement) {
+    val classMember =
+      context.file.findElementAt(context.startOffset)?.parentOfType<PklClassMember>() ?: return
+    val enclosingModule = context.file as? PklModule ?: return
+    val enclosingDef = classMember.parentOfTypes(PklTypeDefOrModule::class) ?: return
+    val psi = enclosingDef.createMember(parentMember, enclosingModule)
+    val insertedPsi = classMember.replace(psi)
+    insertTemplateAtTodoExprs(listOf(insertedPsi), context.editor, context.file)
+  }
+}
+
+class ImplementMemberCompletionProvider : PklCompletionProvider() {
+  override fun addCompletions(
+    parameters: CompletionParameters,
+    context: ProcessingContext,
+    result: CompletionResultSet
+  ) {
+    val position = parameters.position
+    val originalFile = parameters.originalFile
+    val base = originalFile.project.pklBaseModule
+    val def = position.parentOfTypes(PklClass::class, PklModule::class)!!
+    val context = def.enclosingModule?.pklProject
+    // only offer completions for abstract methods for now.
+    // completions for other methods might encourage overriding functions that are meant to be
+    // closed
+    // (Pkl does not have open/closed functions)
+    val parentMethods =
+      def.methods(context)?.values?.filterNot { def.hasDeclaredMethod(it.name) || !it.isAbstract }
+        ?: return
+    for (prop in parentMethods) {
+      val lookupElement =
+        LookupElementBuilder.createWithIcon(prop)
+          .withPresentableText(renderCompletionText(prop))
+          .bold()
+          .withTypeText(prop.getLookupElementType(base, mapOf(), context).render(), true)
+          .withInsertHandler(MemberInsertHandler(prop))
+      result.addElement(lookupElement)
+    }
+  }
+
+  fun renderCompletionText(prop: PklClassMethod): String {
+    return buildString {
+      append("function ")
+      // `name` guaranteed to exist (we only provide completions for members that have names)
+      appendIdentifier(prop.name!!)
+      append("(")
+      prop.parameterList?.elements?.let { params ->
+        var isFirst = true
+        for (param in params) {
+          if (isFirst) {
+            isFirst = false
+          } else {
+            append(", ")
+          }
+          append(param.identifier.text)
+          param.type?.let { type ->
+            append(": ")
+            append(type.text)
+          }
+        }
+      }
+      append(")")
+      prop.returnType?.let { type ->
+        append(": ")
+        append(type.text)
+      }
+      append(" = …")
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/intellij/completion/ImplementMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/completion/ImplementMemberCompletionProvider.kt
@@ -34,7 +34,6 @@ import org.pkl.intellij.psi.enclosingModule
 import org.pkl.intellij.psi.hasDeclaredMethod
 import org.pkl.intellij.psi.methods
 import org.pkl.intellij.psi.pklBaseModule
-import org.pkl.intellij.util.appendIdentifier
 import org.pkl.intellij.util.insertTemplateAtTodoExprs
 
 private class MemberInsertHandler(private val parentMember: PklClassMember) :
@@ -59,7 +58,7 @@ class ImplementMemberCompletionProvider : PklCompletionProvider() {
     val position = parameters.position
     val originalFile = parameters.originalFile
     val base = originalFile.project.pklBaseModule
-    val def = position.parentOfTypes(PklClass::class, PklModule::class)!!
+    val def = position.parentOfTypes(PklClass::class, PklModule::class) ?: return
     val context = def.enclosingModule?.pklProject
     // only offer completions for abstract methods for now.
     // completions for other methods might encourage overriding functions that are meant to be
@@ -83,7 +82,7 @@ class ImplementMemberCompletionProvider : PklCompletionProvider() {
     return buildString {
       append("function ")
       // `name` guaranteed to exist (we only provide completions for members that have names)
-      appendIdentifier(prop.name!!)
+      append(prop.name!!)
       append("(")
       prop.parameterList?.elements?.let { params ->
         var isFirst = true

--- a/src/main/kotlin/org/pkl/intellij/completion/PklCompletionContributor.kt
+++ b/src/main/kotlin/org/pkl/intellij/completion/PklCompletionContributor.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,26 @@ class PklCompletionContributor : CompletionContributor() {
       BASIC,
       psiElement(PklElementTypes.IDENTIFIER).withParent(PklUnqualifiedAccessName::class.java),
       UnqualifiedAccessCompletionProvider()
+    )
+
+    extend(
+      BASIC,
+      psiElement(PklElementTypes.IDENTIFIER)
+        .withParent(PklPropertyName::class.java)
+        .withSuperParent(2, PklClassProperty::class.java),
+      ImplementMemberCompletionProvider()
+    )
+
+    extend(
+      BASIC,
+      psiElement(PklElementTypes.IDENTIFIER).withParent(PklUnqualifiedAccessName::class.java),
+      ImplementMemberCompletionProvider()
+    )
+
+    extend(
+      BASIC,
+      psiElement(PklElementTypes.IDENTIFIER).withParent(PklClassMethod::class.java),
+      ImplementMemberCompletionProvider()
     )
 
     extend(

--- a/src/main/kotlin/org/pkl/intellij/intention/PklImplementMembersQuickFix.kt
+++ b/src/main/kotlin/org/pkl/intellij/intention/PklImplementMembersQuickFix.kt
@@ -15,20 +15,15 @@
  */
 package org.pkl.intellij.intention
 
-import com.intellij.codeInsight.template.TemplateBuilderFactory
-import com.intellij.codeInsight.template.TemplateBuilderImpl
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
-import com.intellij.psi.util.PsiTreeUtil
-import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.psi.*
+import org.pkl.intellij.util.insertTemplateAtTodoExprs
 
 class PklImplementMembersQuickFix(element: PklTypeDefOrModule) :
   LocalQuickFixAndIntentionActionOnPsiElement(element) {
@@ -48,23 +43,19 @@ class PklImplementMembersQuickFix(element: PklTypeDefOrModule) :
     val myModule = startElement.enclosingModule ?: return
     val context = myModule.pklProject
     val parentProperties =
-      def.effectiveParentProperties(context)?.values?.filterNot { def.hasDeclaredProperty(it.name) }
-    val parentMethods = def.methods(context)?.values?.filterNot { def.hasDeclaredMethod(it.name) }
+      def.effectiveParentProperties(context)?.values?.filterNot {
+        def.hasDeclaredProperty(it.name) || !it.isFixedOrConstOrAbstract
+      }
+    val parentMethods =
+      def.methods(context)?.values?.filterNot { def.hasDeclaredMethod(it.name) || !it.isAbstract }
     val parentMembers = (parentProperties ?: listOf()) + (parentMethods ?: listOf())
-    val importList = myModule.importList
     val insertedMembers = mutableListOf<PsiElement>()
     if (def is PklClassBase) {
       if (def.body != null) {
-        def.addMembers(def.body!!.node, parentMembers, importList, myModule, insertedMembers)
+        def.addMembers(def.body!!.node, parentMembers, myModule, insertedMembers)
       } else {
         val newClass = PklPsiFactory.createClassWithEmptyBody(def, project)
-        newClass.addMembers(
-          newClass.body!!.node,
-          parentMembers,
-          importList,
-          myModule,
-          insertedMembers
-        )
+        newClass.addMembers(newClass.body!!.node, parentMembers, myModule, insertedMembers)
         val inserted = def.replace(newClass)
         // replace() may copy the element; re-collect TODOs from the live tree element
         insertedMembers.clear()
@@ -72,32 +63,16 @@ class PklImplementMembersQuickFix(element: PklTypeDefOrModule) :
       }
     } else {
       def as PklModule
-      def.addMembers(def.memberList.node, parentMembers, importList, myModule, insertedMembers)
+      def.addMembers(def.memberList.node, parentMembers, myModule, insertedMembers)
     }
     if (editor != null) {
-      PsiDocumentManager.getInstance(project)
-        .doPostponedOperationsAndUnblockDocument(editor.document)
-      val todoExprs =
-        insertedMembers
-          .flatMap { PsiTreeUtil.collectElementsOfType(it, PklUnqualifiedAccessExpr::class.java) }
-          .filter { it.text == "TODO()" }
-      if (todoExprs.isNotEmpty()) {
-        val templateBuilderFactory =
-          ApplicationManager.getApplication().getService(TemplateBuilderFactory::class.java)
-        val builder = templateBuilderFactory.createTemplateBuilder(file) as TemplateBuilderImpl
-        for (expr in todoExprs) {
-          builder.replaceElement(expr, "TODO()")
-        }
-        editor.caretModel.moveToOffset(todoExprs.first().textOffset)
-        builder.run(editor, true)
-      }
+      insertTemplateAtTodoExprs(insertedMembers, editor, file)
     }
   }
 
   private fun PklTypeDefOrModule.addMembers(
     node: ASTNode,
     parentMembers: List<PklClassMember>,
-    importList: PklImportList,
     myModule: PklModule,
     insertedMembers: MutableList<PsiElement>
   ) {
@@ -120,7 +95,6 @@ class PklImplementMembersQuickFix(element: PklTypeDefOrModule) :
     val indent = if (isModule) "" else "  "
     var isFirst = true
     for (parentMember in parentMembers) {
-      val psi = createMember(myModule, parentMember, importList, project) ?: continue
       if (isFirst) {
         isFirst = false
       } else {
@@ -129,265 +103,10 @@ class PklImplementMembersQuickFix(element: PklTypeDefOrModule) :
       if (!isModule) {
         node.addChild(PsiWhiteSpaceImpl(indent), insertBefore)
       }
+      val psi = createMember(parentMember, myModule)
       node.addChild(psi.node, insertBefore)
       insertedMembers.add(psi)
       node.addChild(PsiWhiteSpaceImpl("\n"), insertBefore)
-    }
-  }
-
-  private fun createMember(
-    myModule: PklModule,
-    parentMember: PklClassMember,
-    importList: PklImportList,
-    project: Project
-  ): PsiElement? {
-    return when {
-      parentMember.isAbstract && parentMember is PklClassProperty -> {
-        val propertyText = renderProperty(myModule, parentMember, importList)
-        PklPsiFactory.createClassProperty(propertyText, project)
-      }
-      parentMember.isAbstract && parentMember is PklClassMethod -> {
-        val text = renderMethod(myModule, parentMember, importList)
-        PklPsiFactory.createClassMethod(text, project)
-      }
-      parentMember is PklClassProperty && parentMember.isFixedOrConst -> {
-        val text = renderFixedConstProperty(parentMember)
-        PklPsiFactory.createClassProperty(text, project)
-      }
-      else -> null
-    }
-  }
-
-  private fun StringBuilder.appendModifiersWithoutAbstract(modifierList: PklModifierList): Boolean {
-    var isFirst = true
-    for (modifier in modifierList.elements) {
-      if (modifier.elementType != PklElementTypes.ABSTRACT) {
-        if (isFirst) {
-          isFirst = false
-        } else {
-          append(" ")
-        }
-        append(modifier.text)
-      }
-    }
-    return !isFirst
-  }
-
-  private fun renderFixedConstProperty(property: PklClassProperty): String {
-    return buildString {
-      if (appendModifiersWithoutAbstract(property.modifierList)) {
-        append(" ")
-      }
-      append(property.nameIdentifier.text)
-      append(" = TODO()")
-    }
-  }
-
-  private fun renderProperty(
-    myModule: PklModule,
-    originalProperty: PklClassProperty,
-    importList: PklImportList,
-  ): String {
-    return buildString {
-      if (appendModifiersWithoutAbstract(originalProperty.modifierList)) {
-        append(" ")
-      }
-      append(originalProperty.nameIdentifier.text)
-      val type = originalProperty.type
-      if (type != null) {
-        append(": ")
-        appendType(type, myModule, importList)
-      }
-      append(" = TODO()")
-    }
-  }
-
-  private fun renderMethod(
-    myModule: PklModule,
-    originalMethod: PklClassMethod,
-    importList: PklImportList,
-  ): String {
-    return buildString {
-      if (appendModifiersWithoutAbstract(originalMethod.modifierList)) {
-        append(' ')
-      }
-      append("function ")
-      append(originalMethod.nameIdentifier!!.text)
-      append('(')
-      originalMethod.parameterList?.let { paramList ->
-        var isFirst = true
-        for (param in paramList.elements) {
-          if (isFirst) {
-            isFirst = false
-          } else {
-            append(", ")
-          }
-          append(param.nameIdentifier!!.text)
-          val type = param.type
-          if (type != null) {
-            append(": ")
-            appendType(type, myModule, importList)
-          }
-        }
-      }
-      append(')')
-      val returnType = originalMethod.returnType
-      if (returnType != null) {
-        append(": ")
-        appendType(returnType, myModule, importList)
-      }
-      append(" = TODO()")
-    }
-  }
-
-  private fun StringBuilder.appendType(
-    type: PklType,
-    myModule: PklModule,
-    imports: PklImportList,
-  ) {
-    type.accept(TypeNameRenderer(this, type, myModule, imports, myModule.pklProject))
-  }
-
-  class TypeNameRenderer(
-    private val sb: StringBuilder,
-    private val type: PklType,
-    private val myModule: PklModule,
-    private val imports: PklImportList,
-    private val context: PklProject?
-  ) : PklVisitor<Unit>() {
-
-    private fun renderSimpleTypeName(o: PklDeclaredType) {
-      val module = o.enclosingModule ?: return
-      if (module == myModule) {
-        sb.append(o.typeName.simpleName.identifier.text)
-        return
-      }
-      val resolvedType = o.typeName.resolve(context) as? PklTypeDefOrModule
-      when {
-        resolvedType == null -> sb.append(o.typeName.simpleName.identifier.text)
-        resolvedType.isInPklBaseModule || resolvedType.enclosingModule == myModule ->
-          sb.append(resolvedType.nameIdentifier?.text ?: "<>")
-        else -> {
-          val importName = imports.findOrInsertImport(resolvedType.enclosingModule!!)
-          sb.append(importName)
-          if (resolvedType !is PklModule) {
-            sb.append(".")
-            sb.append(resolvedType.nameIdentifier!!.text)
-          }
-        }
-      }
-    }
-
-    override fun visitDeclaredType(o: PklDeclaredType) {
-      renderSimpleTypeName(o)
-      val argumentList = o.typeArgumentList
-      if (argumentList != null && argumentList.elements.isNotEmpty()) {
-        sb.append("<")
-        var isFirst = true
-        for (elem in argumentList.elements) {
-          if (isFirst) {
-            isFirst = false
-          } else {
-            sb.append(", ")
-          }
-          elem.accept(this)
-        }
-        sb.append(">")
-      }
-    }
-
-    override fun visitUnknownType(o: PklUnknownType) {
-      sb.append("unknown")
-    }
-
-    override fun visitDefaultType(o: PklDefaultType) {
-      sb.append("*")
-      o.type?.accept(this)
-    }
-
-    override fun visitParenthesizedType(o: PklParenthesizedType) {
-      sb.append("(")
-      o.type?.accept(this)
-      sb.append(")")
-    }
-
-    override fun visitUnionType(o: PklUnionType) {
-      o.leftType.accept(this)
-      sb.append(" | ")
-      o.rightType?.accept(this)
-    }
-
-    override fun visitFunctionType(o: PklFunctionType) {
-      @Suppress("DuplicatedCode") sb.append("(")
-      var isFirst = true
-      for (param in o.functionTypeParameterList.elements) {
-        if (isFirst) {
-          isFirst = false
-        } else {
-          sb.append(", ")
-        }
-        param.accept(this)
-      }
-      sb.append(") -> ")
-      o.type?.accept(this)
-    }
-
-    override fun visitModuleType(o: PklModuleType) {
-      val module = type.enclosingModule ?: return
-      if (module == myModule) {
-        sb.append("module")
-      } else {
-        sb.append(imports.findOrInsertImport(module))
-      }
-    }
-
-    override fun visitNothingType(o: PklNothingType) {
-      sb.append("nothing")
-    }
-
-    override fun visitNullableType(o: PklNullableType) {
-      o.type.accept(this)
-      sb.append("?")
-    }
-
-    override fun visitStringLiteralType(o: PklStringLiteralType) {
-      sb.append(o.text)
-    }
-
-    override fun visitConstrainedType(o: PklConstrainedType) {
-      o.type.accept(this)
-      sb.append("(")
-      var isFirst = true
-      for (expr in o.typeConstraintList.elements) {
-        if (isFirst) {
-          isFirst = false
-        } else {
-          sb.append(", ")
-        }
-        expr.accept(this)
-      }
-      sb.append(")")
-    }
-
-    override fun visitExpr(o: PklExpr) {
-      // TODO this doesn't handle member access.
-      sb.append(o.text)
-    }
-
-    override fun visitTypeTestExpr(o: PklTypeTestExpr) {
-      o.expr.accept(this)
-      sb.append(' ')
-      sb.append(o.operator.text)
-      sb.append(' ')
-      o.type.accept(this)
-    }
-
-    override fun visitTypeCastExpr(o: PklTypeCastExpr) {
-      o.expr.accept(this)
-      sb.append(' ')
-      sb.append(o.operator.text)
-      sb.append(' ')
-      o.type.accept(this)
     }
   }
 }

--- a/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklModifierListOwner.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ interface PklModifierListOwner : PklElement {
       TokenSet.create(PklElementTypes.LOCAL, PklElementTypes.CONST, PklElementTypes.FIXED)
 
     private val abstractOrOpen = TokenSet.create(PklElementTypes.ABSTRACT, PklElementTypes.OPEN)
+
+    private val fixedOrConstOrAbstract =
+      TokenSet.create(PklElementTypes.FIXED, PklElementTypes.CONST, PklElementTypes.ABSTRACT)
   }
 
   val modifierList: PklModifierList?
@@ -59,6 +62,9 @@ interface PklModifierListOwner : PklElement {
 
   val isLocalOrConstOrFixed: Boolean
     get() = hasAnyModifier(localOrConstOrFixed)
+
+  val isFixedOrConstOrAbstract: Boolean
+    get() = hasAnyModifier(fixedOrConstOrAbstract)
 
   private fun hasModifier(modifier: IElementType): Boolean {
     val modifiers = modifierList?.elements ?: return false

--- a/src/main/kotlin/org/pkl/intellij/psi/Refactorings.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/Refactorings.kt
@@ -284,3 +284,245 @@ private class ReplacementVisitor(
     }
   }
 }
+
+fun PklTypeDefOrModule.createMember(
+  parentMember: PklClassMember,
+  myModule: PklModule
+): PklClassMember {
+  return when (parentMember) {
+    is PklClassProperty -> {
+      val text = renderProperty(myModule, parentMember)
+      PklPsiFactory.createClassProperty(text, project)
+    }
+    is PklClassMethod -> {
+      val text = renderMethod(myModule, parentMember)
+      PklPsiFactory.createClassMethod(text, project)
+    }
+    else -> throw IllegalArgumentException("Expected either a class method or class property")
+  }
+}
+
+private fun StringBuilder.appendModifiersWithoutAbstractOrExternal(
+  modifierList: PklModifierList
+): Boolean {
+  var isFirst = true
+  for (modifier in modifierList.elements) {
+    if (
+      modifier.elementType == PklElementTypes.ABSTRACT ||
+        modifier.elementType == PklElementTypes.EXTERNAL
+    ) {
+      continue
+    }
+    if (isFirst) {
+      isFirst = false
+    } else {
+      append(" ")
+    }
+    append(modifier.text)
+  }
+  return !isFirst
+}
+
+private fun renderProperty(
+  myModule: PklModule,
+  originalProperty: PklClassProperty,
+): String {
+  return buildString {
+    if (appendModifiersWithoutAbstractOrExternal(originalProperty.modifierList)) {
+      append(" ")
+    }
+    append(originalProperty.nameIdentifier.text)
+    val type = originalProperty.type
+    if (type != null) {
+      append(": ")
+      appendType(type, myModule)
+    }
+    append(" = TODO()")
+  }
+}
+
+private fun renderMethod(
+  myModule: PklModule,
+  originalMethod: PklClassMethod,
+): String {
+  return buildString {
+    if (appendModifiersWithoutAbstractOrExternal(originalMethod.modifierList)) {
+      append(' ')
+    }
+    append("function ")
+    append(originalMethod.nameIdentifier!!.text)
+    append('(')
+    originalMethod.parameterList?.let { paramList ->
+      var isFirst = true
+      for (param in paramList.elements) {
+        if (isFirst) {
+          isFirst = false
+        } else {
+          append(", ")
+        }
+        append(param.nameIdentifier!!.text)
+        val type = param.type
+        if (type != null) {
+          append(": ")
+          appendType(type, myModule)
+        }
+      }
+    }
+    append(')')
+    val returnType = originalMethod.returnType
+    if (returnType != null) {
+      append(": ")
+      appendType(returnType, myModule)
+    }
+    append(" = TODO()")
+  }
+}
+
+private fun StringBuilder.appendType(type: PklType, myModule: PklModule) {
+  type.accept(TypeNameHandler(this, type, myModule))
+}
+
+private class TypeNameHandler(
+  private val sb: StringBuilder,
+  private val type: PklType,
+  private val myModule: PklModule,
+) : PklVisitor<Unit>() {
+
+  private val imports = myModule.importList
+
+  private val context = myModule.pklProject
+
+  private fun renderSimpleTypeName(o: PklDeclaredType) {
+    val module = o.enclosingModule ?: return
+    if (module == myModule) {
+      sb.append(o.typeName.simpleName.identifier.text)
+      return
+    }
+    val resolvedType = o.typeName.resolve(context) as? PklTypeDefOrModule
+    when {
+      resolvedType == null -> sb.append(o.typeName.simpleName.identifier.text)
+      resolvedType.isInPklBaseModule || resolvedType.enclosingModule == myModule ->
+        sb.append(resolvedType.nameIdentifier?.text ?: "<>")
+      else -> {
+        val importName = imports.findOrInsertImport(resolvedType.enclosingModule!!)
+        sb.append(importName)
+        if (resolvedType !is PklModule) {
+          sb.append(".")
+          sb.append(resolvedType.nameIdentifier!!.text)
+        }
+      }
+    }
+  }
+
+  override fun visitDeclaredType(o: PklDeclaredType) {
+    renderSimpleTypeName(o)
+    val argumentList = o.typeArgumentList
+    if (argumentList != null && argumentList.elements.isNotEmpty()) {
+      sb.append("<")
+      var isFirst = true
+      for (elem in argumentList.elements) {
+        if (isFirst) {
+          isFirst = false
+        } else {
+          sb.append(", ")
+        }
+        elem.accept(this)
+      }
+      sb.append(">")
+    }
+  }
+
+  override fun visitUnknownType(o: PklUnknownType) {
+    sb.append("unknown")
+  }
+
+  override fun visitDefaultType(o: PklDefaultType) {
+    sb.append("*")
+    o.type?.accept(this)
+  }
+
+  override fun visitParenthesizedType(o: PklParenthesizedType) {
+    sb.append("(")
+    o.type?.accept(this)
+    sb.append(")")
+  }
+
+  override fun visitUnionType(o: PklUnionType) {
+    o.leftType.accept(this)
+    sb.append(" | ")
+    o.rightType?.accept(this)
+  }
+
+  override fun visitFunctionType(o: PklFunctionType) {
+    @Suppress("DuplicatedCode") sb.append("(")
+    var isFirst = true
+    for (param in o.functionTypeParameterList.elements) {
+      if (isFirst) {
+        isFirst = false
+      } else {
+        sb.append(", ")
+      }
+      param.accept(this)
+    }
+    sb.append(") -> ")
+    o.type?.accept(this)
+  }
+
+  override fun visitModuleType(o: PklModuleType) {
+    val module = type.enclosingModule ?: return
+    if (module == myModule) {
+      sb.append("module")
+    } else {
+      sb.append(imports.findOrInsertImport(module))
+    }
+  }
+
+  override fun visitNothingType(o: PklNothingType) {
+    sb.append("nothing")
+  }
+
+  override fun visitNullableType(o: PklNullableType) {
+    o.type.accept(this)
+    sb.append("?")
+  }
+
+  override fun visitStringLiteralType(o: PklStringLiteralType) {
+    sb.append(o.text)
+  }
+
+  override fun visitConstrainedType(o: PklConstrainedType) {
+    o.type.accept(this)
+    sb.append("(")
+    var isFirst = true
+    for (expr in o.typeConstraintList.elements) {
+      if (isFirst) {
+        isFirst = false
+      } else {
+        sb.append(", ")
+      }
+      expr.accept(this)
+    }
+    sb.append(")")
+  }
+
+  override fun visitExpr(o: PklExpr) {
+    // TODO this doesn't handle member access.
+    sb.append(o.text)
+  }
+
+  override fun visitTypeTestExpr(o: PklTypeTestExpr) {
+    o.expr.accept(this)
+    sb.append(' ')
+    sb.append(o.operator.text)
+    sb.append(' ')
+    o.type.accept(this)
+  }
+
+  override fun visitTypeCastExpr(o: PklTypeCastExpr) {
+    o.expr.accept(this)
+    sb.append(' ')
+    sb.append(o.operator.text)
+    sb.append(' ')
+    o.type.accept(this)
+  }
+}

--- a/src/main/kotlin/org/pkl/intellij/util/Util.kt
+++ b/src/main/kotlin/org/pkl/intellij/util/Util.kt
@@ -16,8 +16,12 @@
 package org.pkl.intellij.util
 
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.codeInsight.template.TemplateBuilderFactory
+import com.intellij.codeInsight.template.TemplateBuilderImpl
 import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
@@ -26,9 +30,11 @@ import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.PsiTreeUtil
 import java.io.InputStream
 import java.io.OutputStream
 import java.math.BigInteger
@@ -66,6 +72,7 @@ import org.pkl.intellij.psi.PklTypeTestExpr
 import org.pkl.intellij.psi.PklUnaryMinusExpr
 import org.pkl.intellij.psi.PklUnqualifiedAccessExpr
 import org.pkl.intellij.psi.escapedText
+import org.pkl.parser.Lexer
 
 private const val SIGNIFICAND_MASK = 0x000fffffffffffffL
 
@@ -449,4 +456,29 @@ fun PklExpr.toDisplayText(): String? {
 private fun PklArgumentList?.renderMethodCallArguments(): String {
   if (this == null) return ""
   return elements.joinToString(", ", prefix = "(", postfix = ")") { it.toDisplayText() ?: "…" }
+}
+
+fun StringBuilder.appendIdentifier(identifier: String): StringBuilder =
+  append(Lexer.maybeQuoteIdentifier(identifier))
+
+// Finds the `T_ODO()` expressions, and inserts a template
+fun insertTemplateAtTodoExprs(elems: List<PsiElement>, editor: Editor, file: PsiFile) {
+  require(elems.isNotEmpty())
+
+  val project = elems.first().project
+  PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+
+  val todoExprs =
+    elems
+      .flatMap { PsiTreeUtil.collectElementsOfType(it, PklUnqualifiedAccessExpr::class.java) }
+      .filter { it.text == "TODO()" }
+
+  val templateBuilderFactory =
+    ApplicationManager.getApplication().getService(TemplateBuilderFactory::class.java)
+  val builder = templateBuilderFactory.createTemplateBuilder(file) as TemplateBuilderImpl
+  for (expr in todoExprs) {
+    builder.replaceElement(expr, "TODO()")
+  }
+  editor.caretModel.moveToOffset(todoExprs.first().textOffset)
+  builder.run(editor, true)
 }

--- a/src/test/kotlin/org/pkl/intellij/annotator/PklExtendsClauseAnnotatorTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/annotator/PklExtendsClauseAnnotatorTest.kt
@@ -185,7 +185,7 @@ class PklExtendsClauseAnnotatorTest {
           fixed name: String
         }
         class Child extends Base {
-          fixed name = TODO()
+          fixed name: String = TODO()
         }
         """
     )

--- a/src/test/kotlin/org/pkl/intellij/completion/CompletionTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/completion/CompletionTest.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.intellij.completion
 
+import com.intellij.codeInsight.lookup.LookupElementPresentation
 import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.pkl.intellij.PklFileType
@@ -23,6 +24,15 @@ import org.pkl.intellij.packages.dto.PackageUri
 import org.pkl.intellij.packages.pklPackageService
 
 class CompletionTest : PklTestCase() {
+  private fun lookupPresentableStrings(): List<String> {
+    val presentation = LookupElementPresentation()
+    return myFixture.lookupElements?.map {
+      it.renderElement(presentation)
+      presentation.itemText ?: ""
+    }
+      ?: emptyList()
+  }
+
   fun `test complete from lexical scope`() {
     myFixture.configureByText(
       PklFileType,
@@ -152,6 +162,89 @@ class CompletionTest : PklTestCase() {
     myFixture.completeBasic()
     val lookupStrings = myFixture.lookupElementStrings
     assertThat(lookupStrings).contains("bar = ")
+  }
+
+  fun `test complete implement member`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+        abstract class Base {
+          abstract function someMethod(elems: Listing<String>)
+        }
+
+        class MyClass extends Base {
+          function some<caret>
+        }
+        """
+        .trimIndent()
+    )
+    myFixture.completeBasic()
+    assertThat(myFixture.editor.document.text)
+      .contains("function someMethod(elems: Listing<String>) = TODO()")
+  }
+
+  fun `test complete implement member shows all unimplemented methods`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+        abstract class Base {
+          abstract function method1(): String
+          abstract function method2(x: Int): Boolean
+        }
+
+        class MyClass extends Base {
+          function m<caret>
+        }
+        """
+        .trimIndent()
+    )
+    myFixture.completeBasic()
+    val lookupStrings = lookupPresentableStrings()
+    assertThat(lookupStrings)
+      .contains("function method1(): String = …", "function method2(x: Int): Boolean = …")
+  }
+
+  fun `test complete implement member excludes already implemented methods`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+        abstract class Base {
+          abstract function method1(): String
+          abstract function method2(x: Int): Boolean
+          abstract function method3(x: Int): Boolean
+        }
+
+        class MyClass extends Base {
+          function method1(): String = "done"
+
+          function m<caret>
+        }
+        """
+        .trimIndent()
+    )
+    myFixture.completeBasic()
+    val lookupStrings = lookupPresentableStrings()
+    assertThat(lookupStrings).hasSize(2)
+    assertThat(lookupStrings).contains("function method2(x: Int): Boolean = …")
+    assertThat(lookupStrings).contains("function method3(x: Int): Boolean = …")
+  }
+
+  fun `test complete implement member in module`() {
+    myFixture.configureByFiles(
+      "implement-member/ConcreteModule.pkl",
+      "implement-member/AbstractModule.pkl"
+    )
+    myFixture.completeBasic()
+    assertThat(myFixture.editor.document.text).contains("function greet(name: String): String")
+  }
+
+  fun `test complete implement member in module excludes already implemented methods`() {
+    myFixture.configureByFiles(
+      "implement-member/PartiallyImplementedModule.pkl",
+      "implement-member/AbstractModule.pkl"
+    )
+    myFixture.completeBasic()
+    assertThat(myFixture.editor.document.text).contains("function greet(name: String): String")
   }
 
   override val fixtureDir: Path?

--- a/src/test/kotlin/org/pkl/intellij/completion/CompletionTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/completion/CompletionTest.kt
@@ -15,7 +15,10 @@
  */
 package org.pkl.intellij.completion
 
+import com.intellij.codeInsight.lookup.Lookup
 import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupManager
+import com.intellij.codeInsight.lookup.impl.LookupImpl
 import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.pkl.intellij.PklFileType
@@ -227,6 +230,42 @@ class CompletionTest : PklTestCase() {
     assertThat(lookupStrings).hasSize(2)
     assertThat(lookupStrings).contains("function method2(x: Int): Boolean = …")
     assertThat(lookupStrings).contains("function method3(x: Int): Boolean = …")
+  }
+
+  fun `test complete member with quoted identifier`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+        abstract class Base {
+          abstract function `my fun`(): String
+        }
+
+        class MyClass extends Base {
+          function <caret>
+        }
+        """
+        .trimIndent()
+    )
+    myFixture.completeBasic()
+    val lookupElements = myFixture.lookupElements
+    assertThat(lookupElements).hasSize(1)
+    (LookupManager.getActiveLookup(editor) as LookupImpl).finishLookup(
+      Lookup.NORMAL_SELECT_CHAR,
+      lookupElements!!.first()
+    )
+    assertThat(
+      myFixture.editor.document.text ==
+        """
+        abstract class Base {
+          abstract function `my fun`(): String
+        }
+
+        class MyClass extends Base {
+          function `my fun`() = "TODO()
+        }
+        """
+          .trimIndent()
+    )
   }
 
   fun `test complete implement member in module`() {

--- a/src/test/resources/completion/implement-member/AbstractModule.pkl
+++ b/src/test/resources/completion/implement-member/AbstractModule.pkl
@@ -1,0 +1,5 @@
+abstract module AbstractModule
+
+abstract function greet(name: String): String
+
+abstract function farewell(name: String): String

--- a/src/test/resources/completion/implement-member/ConcreteModule.pkl
+++ b/src/test/resources/completion/implement-member/ConcreteModule.pkl
@@ -1,0 +1,3 @@
+extends "AbstractModule.pkl"
+
+function g<caret>

--- a/src/test/resources/completion/implement-member/PartiallyImplementedModule.pkl
+++ b/src/test/resources/completion/implement-member/PartiallyImplementedModule.pkl
@@ -1,0 +1,5 @@
+extends "AbstractModule.pkl"
+
+function farewell(name: String): String = "Goodbye, \(name)"
+
+function g<caret>


### PR DESCRIPTION
This adds logic to auto-complete methods of abstract methods on the superclass.

Additionally:

* Move much of the logic around "implement member" to Refactorings.kt and Utils.kt, and use said shared logic in both ImplementMemberCompletionProvider and PklImplementMembersQuickFix.
* Unify the rendering of overriding properties regardless of abstract, fixed, or const modifiers.