### PR TITLE
Downgrade diagnostics around abstract members

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/annotator/PklExtendsClauseAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklExtendsClauseAnnotator.kt
@@ -189,7 +189,7 @@ class PklExtendsClauseAnnotator : PklAnnotator() {
       val tooltipMessage =
         "${entityName.escapeXml()} ${classOrModuleName.escapeXml()} is not abstract and does not implement ${memberEntityName.escapeXml()} '${parentName.escapeXml()}'"
       holder
-        .newAnnotation(HighlightSeverity.ERROR, message)
+        .newAnnotation(HighlightSeverity.WARNING, message)
         .apply {
           range(element.textRange)
           tooltip(tooltipMessage)

--- a/src/main/kotlin/org/pkl/intellij/annotator/PklMemberAnnotator.kt
+++ b/src/main/kotlin/org/pkl/intellij/annotator/PklMemberAnnotator.kt
@@ -399,18 +399,18 @@ class PklMemberAnnotator : PklAnnotator() {
     if (containingClassOrModule.getAbstractModifier() == null) {
       if (containingClassOrModule is PklModule) {
         createAnnotation(
-          HighlightSeverity.ERROR,
+          HighlightSeverity.WARNING,
           myAbstractModifier.textRange,
-          "Cannot declare an abstract member inside a non-abstract module",
-          "Cannot declare an abstract member inside a non-abstract module",
+          "Abstract member declared inside a non-abstract module. This will be an error in the future.",
+          "Abstract member declared inside a non-abstract module. This will be an error in the future.",
           holder
         )
       } else {
         createAnnotation(
-          HighlightSeverity.ERROR,
+          HighlightSeverity.WARNING,
           myAbstractModifier.textRange,
-          "Cannot declare an abstract member inside a non-abstract class",
-          "Cannot declare an abstract member inside a non-abstract class",
+          "Abstract member declared inside a non-abstract class. This will be an error in the future.",
+          "Abstract member declared inside a non-abstract class. This will be an error in the future.",
           holder
         )
       }

--- a/src/test/kotlin/org/pkl/intellij/annotator/PklExtendsClauseAnnotatorTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/annotator/PklExtendsClauseAnnotatorTest.kt
@@ -70,7 +70,7 @@ class PklExtendsClauseAnnotatorTest {
       abstract class Base {
         abstract name: String
       }
-      class Child <error descr="class Child is not abstract and does not implement property 'name'">extends Base</error> {}
+      class Child <warning descr="class Child is not abstract and does not implement property 'name'">extends Base</warning> {}
       """
     )
   }
@@ -82,7 +82,7 @@ class PklExtendsClauseAnnotatorTest {
       abstract class Base {
         abstract function greet(): String
       }
-      class Child <error descr="class Child is not abstract and does not implement method 'greet'">extends Base</error> {}
+      class Child <warning descr="class Child is not abstract and does not implement method 'greet'">extends Base</warning> {}
       """
     )
   }

--- a/src/test/kotlin/org/pkl/intellij/annotator/PklMemberAnnotatorTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/annotator/PklMemberAnnotatorTest.kt
@@ -56,15 +56,15 @@ class PklMemberAnnotatorTest {
   fun `abstract member inside non-abstract class`() {
     checkHighlighting(
       """
-      <error descr="Cannot declare an abstract member inside a non-abstract module">abstract</error> bar: Int
+        <warning descr="Abstract member declared inside a non-abstract module. This will be an error in the future.">abstract</warning> bar: Int
 
-      <error descr="Cannot declare an abstract member inside a non-abstract module">abstract</error> function bar(): Int
+        <warning descr="Abstract member declared inside a non-abstract module. This will be an error in the future.">abstract</warning> function bar(): Int
 
-      class Foo {
-        <error descr="Cannot declare an abstract member inside a non-abstract class">abstract</error> bar: Int
+        class Foo {
+          <warning descr="Abstract member declared inside a non-abstract class. This will be an error in the future.">abstract</warning> bar: Int
 
-        <error descr="Cannot declare an abstract member inside a non-abstract class">abstract</error> function bar(): Int
-      }
+          <warning descr="Abstract member declared inside a non-abstract class. This will be an error in the future.">abstract</warning> function bar(): Int
+        }
     """
         .trimIndent()
     )


### PR DESCRIPTION
We removed the enforcement on the Pkl side around abstract members.

This downgrades the existing diagnostics to warning level.