### PR TITLE
Add support for resolving `this` and `module` keywords in member links

### DIFF
--- a/src/main/kotlin/org/pkl/intellij/documentation/PkldocLinkGeneratingProvider.kt
+++ b/src/main/kotlin/org/pkl/intellij/documentation/PkldocLinkGeneratingProvider.kt
@@ -23,7 +23,7 @@ import org.intellij.markdown.html.HtmlGenerator
 import org.pkl.intellij.util.escapeXml
 
 object PkldocLinkGeneratingProvider : GeneratingProvider {
-  val keywords = setOf("null", "true", "false", "this", "unknown", "nothing")
+  val keywords = setOf("null", "true", "false", "this", "unknown", "nothing", "module")
 
   override fun processNode(
     visitor: HtmlGenerator.HtmlGeneratingVisitor,

--- a/src/main/kotlin/org/pkl/intellij/psi/Extensions.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/Extensions.kt
@@ -460,7 +460,9 @@ fun PklImportList.findOrInsertImport(module: PklModule): String? {
       }
       else -> {
         val myModule = enclosingModule ?: return null
-        VfsUtilCore.findRelativePath(myModule.virtualFile, module.virtualFile, '/') ?: canonicalUri
+        val myVirtualFile = myModule.originalFile.virtualFile ?: return null
+        val otherVirtualFile = module.originalFile.virtualFile ?: return null
+        VfsUtilCore.findRelativePath(myVirtualFile, otherVirtualFile, '/') ?: canonicalUri
       }
     }
 

--- a/src/main/kotlin/org/pkl/intellij/psi/PklDocCommentReference.kt
+++ b/src/main/kotlin/org/pkl/intellij/psi/PklDocCommentReference.kt
@@ -36,7 +36,11 @@ class PklDocCommentReference(
       )
         fullText
       else element.text.substring(fullLabelTextRange.startOffset, rangeInElement.endOffset)
-    if (link in PkldocLinkGeneratingProvider.keywords) {
+    if (
+      fullText in PkldocLinkGeneratingProvider.keywords &&
+        fullText != "module" &&
+        fullText != "this"
+    ) {
       return null
     }
     val project = element.project

--- a/src/main/kotlin/org/pkl/intellij/resolve/DocCommentResolvers.kt
+++ b/src/main/kotlin/org/pkl/intellij/resolve/DocCommentResolvers.kt
@@ -20,6 +20,8 @@ import com.intellij.psi.PsiManager
 import org.pkl.intellij.packages.dto.PklProject
 import org.pkl.intellij.psi.enclosingModule
 import org.pkl.intellij.psi.pklBaseModule
+import org.pkl.intellij.resolve.Resolvers.resolveDocCommentModuleOrThisKeyword
+import org.pkl.intellij.type.computeThisType
 
 object DocCommentResolvers {
   fun resolveLink(psiManager: PsiManager, link: String, position: PsiElement): PsiElement? {
@@ -62,6 +64,10 @@ object DocCommentResolvers {
     val isProperty = !link.endsWith("()")
     val memberName = if (isProperty) link else link.dropLast(2)
     val base = psiManager.project.pklBaseModule
+    resolveDocCommentModuleOrThisKeyword(link, position)?.let {
+      return it
+    }
+    val thisType = position.computeThisType(base, mapOf(), context)
     val visitor =
       ResolveVisitors.firstElementNamed(
         memberName,
@@ -69,7 +75,7 @@ object DocCommentResolvers {
       )
     return Resolvers.resolveUnqualifiedAccess(
       position,
-      null,
+      thisType,
       isProperty,
       base,
       mapOf(),

--- a/src/main/kotlin/org/pkl/intellij/resolve/Resolvers.kt
+++ b/src/main/kotlin/org/pkl/intellij/resolve/Resolvers.kt
@@ -187,6 +187,17 @@ object Resolvers {
     }
   }
 
+  fun resolveDocCommentModuleOrThisKeyword(
+    link: String,
+    position: PsiElement
+  ): PklTypeDefOrModule? {
+    return when (link) {
+      "module" -> position.enclosingModule
+      "this" -> position as? PklClass ?: position.parentOfTypes(PklClass::class, PklModule::class)
+      else -> null
+    }
+  }
+
   fun <R> resolveQualifiedDocCommentMemberLink(
     linkText: String,
     position: PsiElement,
@@ -202,19 +213,17 @@ object Resolvers {
         // Class.property, Class.method()
         // module.Class, module.TypeAlias, module.property, module.method()
         val classOrModuleName = parts[0]
+
+        resolveDocCommentModuleOrThisKeyword(classOrModuleName, position)?.let { node ->
+          visitDocCommentClassOrModuleMembersForDocComment(node, isProperty, visitor, context)
+          return
+        }
+
         val resolveResult =
           enclosingModule?.imports?.find { it.memberName == classOrModuleName }?.resolve(context)
             as? SimpleModuleResolutionResult
-        resolveResult?.resolved?.cache(context)?.let { cache ->
-          if (isProperty) {
-            for ((name, def) in cache.typeDefsAndProperties) {
-              visitor.visit(name, def, mapOf(), context)
-            }
-          } else {
-            for ((methodName, method) in cache.methods) {
-              visitor.visit(methodName, method, mapOf(), context)
-            }
-          }
+        resolveResult?.resolved?.let { module ->
+          visitDocCommentClassOrModuleMembersForDocComment(module, isProperty, visitor, context)
           return
         }
 
@@ -222,33 +231,56 @@ object Resolvers {
         val clazz =
           resolveUnqualifiedTypeName(position, base, mapOf(), typeNameVisitor, context) as? PklClass
             ?: return
-        if (isProperty) {
-          for (property in clazz.properties) {
-            visitor.visit(property.name, property, mapOf(), context)
-          }
-        } else {
-          for (method in clazz.methods) {
-            val name = method.name ?: continue
-            visitor.visit(name, method, mapOf(), context)
-          }
-        }
+        visitDocCommentClassOrModuleMembersForDocComment(clazz, isProperty, visitor, context)
       }
       3 -> {
         // module.Class.property, module.Class.method()
         val moduleName = parts[0]
         val className = parts[1]
-        val module =
-          enclosingModule?.imports?.find { it.memberName == moduleName }?.resolve(context)
-            as? SimpleModuleResolutionResult
-            ?: return
-        val clazz = module.resolved?.cache(context)?.types?.get(className) as? PklClass ?: return
+        var resolvedModule = resolveDocCommentModuleOrThisKeyword(moduleName, position)
+        if (resolvedModule == null) {
+          resolvedModule =
+            resolveDocCommentModuleOrThisKeyword(moduleName, position)
+              ?: (enclosingModule?.imports?.find { it.memberName == moduleName }?.resolve(context)
+                  as? SimpleModuleResolutionResult)
+                ?.resolved
+        }
+        if (resolvedModule !is PklModule) return
+        val clazz = resolvedModule.cache(context).types[className] as? PklClass ?: return
+        visitDocCommentClassOrModuleMembersForDocComment(clazz, isProperty, visitor, context)
+      }
+    }
+  }
+
+  @Suppress("DuplicatedCode")
+  private fun <R> visitDocCommentClassOrModuleMembersForDocComment(
+    node: PklTypeDefOrModule,
+    isProperty: Boolean,
+    visitor: ResolveVisitor<R>,
+    context: PklProject?,
+  ) {
+    when (node) {
+      is PklModule -> {
+        val cache = node.cache(context)
         if (isProperty) {
-          for (property in clazz.properties) {
-            visitor.visit(property.name, property, mapOf(), context)
+          for ((name, def) in cache.typeDefsAndProperties) {
+            visitor.visit(name, def, mapOf(), context)
           }
         } else {
-          for (method in clazz.methods) {
-            val name = method.name ?: continue
+          for ((methodName, method) in cache.methods) {
+            visitor.visit(methodName, method, mapOf(), context)
+          }
+        }
+      }
+      else -> {
+        node as PklClass
+        val cache = node.cache(context)
+        if (isProperty) {
+          for ((name, property) in cache.properties) {
+            visitor.visit(name, property, mapOf(), context)
+          }
+        } else {
+          for ((name, method) in cache.methods) {
             visitor.visit(name, method, mapOf(), context)
           }
         }

--- a/src/test/kotlin/org/pkl/intellij/resolve/DocCommentMemberLinkResolveTest.kt
+++ b/src/test/kotlin/org/pkl/intellij/resolve/DocCommentMemberLinkResolveTest.kt
@@ -21,6 +21,7 @@ import org.pkl.intellij.PklTestCase
 import org.pkl.intellij.psi.PklClass
 import org.pkl.intellij.psi.PklClassMethod
 import org.pkl.intellij.psi.PklClassProperty
+import org.pkl.intellij.psi.PklModule
 
 class DocCommentMemberLinkResolveTest : PklTestCase() {
   fun `test resolve member link`() {
@@ -132,5 +133,141 @@ class DocCommentMemberLinkResolveTest : PklTestCase() {
     assertThat(resolved).isInstanceOf(PklClassMethod::class.java)
     resolved as PklClassMethod
     assertThat(resolved.name).isEqualTo("baz")
+  }
+
+  fun `test resolve member link - this keyword`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      module MyModule
+
+      /// This is [this<caret>]
+      prop1: String
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklModule::class.java)
+  }
+
+  fun `test resolve member link - this keyword 2`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      /// This is [this<caret>]
+      class MyClass
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklClass::class.java)
+  }
+
+  fun `test resolve member link - module keyword`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      module MyModule
+
+      /// This is like [module<caret>]
+      class MyClass
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklModule::class.java)
+  }
+
+  fun `test resolve qualified member link - module keyword`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      module MyModule
+
+      /// This is like [module.MyClass<caret>]
+      class MyClass
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklClass::class.java)
+    resolved as PklClass
+    assertThat(resolved.name).isEqualTo("MyClass")
+  }
+
+  fun `test resolve qualified member link - this keyword`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      module MyModule
+
+      /// The name on MyModule
+      name: String
+
+      /// This is like [this.name<caret>]
+      class MyClass {
+        /// The name inside MyClass
+        name: String
+      }
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
+    resolved as PklClassProperty
+    assertThat(resolved.effectiveDocComment(null)!!.contents).isEqualTo("The name inside MyClass")
+  }
+
+  fun `test resolve qualified member link - three dots starting with module keyword`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      module MyModule
+
+      /// This is like [module.MyClass.name<caret>]
+      name: String
+
+      class MyClass {
+        /// The name inside MyClass
+        name: String
+      }
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
+    resolved as PklClassProperty
+    assertThat(resolved.effectiveDocComment(null)!!.contents).isEqualTo("The name inside MyClass")
+  }
+
+  fun `test resolve super property`() {
+    myFixture.configureByText(
+      PklFileType,
+      """
+      module MyModule
+
+      /// This is like [module.MyClass.name<caret>]
+      name: String
+
+      open class Base {
+        /// The name inside Base
+        name: String
+      }
+
+      class MyClass extends Base
+    """
+        .trimIndent()
+    )
+    val element = myFixture.getReferenceAtCaretPosition()!!
+    val resolved = element.resolve()
+    assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
+    resolved as PklClassProperty
+    assertThat(resolved.effectiveDocComment(null)!!.contents).isEqualTo("The name inside Base")
   }
 }


### PR DESCRIPTION
Also:

* Fix an issue where super properties are not resolved
* Fix an issue where the "implement member" action can fail with a NPE